### PR TITLE
Fix two critical bugs in centrifugal compressor solver (radial area + massflow sign)

### DIFF
--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -323,7 +323,7 @@ def rotor_calc(
             tau_is = (row.P0_is / upstream.P0) ** ((row.gamma - 1.0) / row.gamma)
             row.T0_is = upstream.T0 * tau_is
     
-        return np.abs(upstream.total_massflow - total_massflow_local)
+        return np.abs(np.abs(upstream.total_massflow) - np.abs(total_massflow_local))
     
     def solve_massflow_for_current_loss() -> None:
         res = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")

--- a/turbodesign/flow_math.py
+++ b/turbodesign/flow_math.py
@@ -35,9 +35,11 @@ def compute_streamline_areas(row: BladeRow) -> Tuple[float, npt.NDArray]:
             total_area += delta
         else:  # Radial machines
             dx = row.x[j] - row.x[j - 1]
-            S = row.r[j] - row.r[j - 1]
-            C = np.sqrt(1 + ((row.r[j] - row.r[j - 1]) / dx) ** 2)
-            streamline_area[j] = 2 * np.pi * C * (S / 2 * dx ** 2 + row.r[j - 1] * dx)
+            dr = row.r[j] - row.r[j - 1]
+            dl = np.sqrt(dx**2 + dr**2)
+            # Signed area: sign follows dx to maintain massflow sign convention
+            sign = -1.0 if dx < 0 else 1.0
+            streamline_area[j] = sign * np.pi * (row.r[j] + row.r[j - 1]) * dl
             total_area += streamline_area[j]
     return total_area, streamline_area
 


### PR DESCRIPTION
## Summary

Two bugs that cause incorrect or trivial results for centrifugal (radial) compressors:

- **Fix incorrect frustum area formula in `flow_math.py`**
- **Fix massflow sign mismatch in `compressor_math.py`**

---

## Bug 1 — Incorrect streamline area for radial machines (`flow_math.py`)

**Function**: `compute_streamline_areas`, radial branch (`else` clause)

The original formula can produce negative or incorrectly scaled areas for centrifugal
passages where `dx` is small relative to `dr`.

**Before (incorrect):**
```python
S  = row.r[j] - row.r[j - 1]
C  = np.sqrt(1 + ((row.r[j] - row.r[j-1]) / dx)**2)
streamline_area[j] = 2 * np.pi * C * (S / 2 * dx**2 + row.r[j-1] * dx)
```

**After — standard frustum lateral area, sign preserved for massflow convention:**
```python
dr = row.r[j] - row.r[j - 1]
dl = np.sqrt(dx**2 + dr**2)
sign = -1.0 if dx < 0 else 1.0
streamline_area[j] = sign * np.pi * (row.r[j] + row.r[j - 1]) * dl
```

**Impact**: The corrupted area caused unrealistically low pressure ratios (~2.2–2.4
instead of the physically expected ~4–5), and drove optimizers toward abnormally large
geometries to compensate.

---

## Bug 2 — Massflow sign mismatch in `compressor_math.py`

**Function**: `rotor_calc`, objective inside `calculate_vm_func`

For centrifugal passages `total_massflow_local` is negative (area sign convention).
Comparing magnitudes explicitly avoids precision loss and edge cases where the solver
converges to M_rel → 0 (no energy transfer).

**Before:**
```python
return np.abs(upstream.total_massflow - total_massflow_local)
```

**After:**
```python
return np.abs(np.abs(upstream.total_massflow) - np.abs(total_massflow_local))
```

---

## Testing

Validated on a centrifugal compressor for a microturbine:
R2=52 mm, RPM=109 905, β₂=−16.6°, 20 blades, ṁ=0.25 kg/s

|              | PR   | η_poly |
|--------------|------|--------|
| Before fixes | ~2.3 | ~0.30  |
| After fixes  | ~5.1 | ~0.62  |

Axial-machine tests are unaffected — the radial branch is only entered
when `passage_type == PassageType.Centrifugal`.
