### PR TITLE
Restore dropped exponents in TD2 Reynolds and K&O shock-loss corrections

### DIFF
--- a/turbodesign/loss/turbine/TD2.py
+++ b/turbodesign/loss/turbine/TD2.py
@@ -66,23 +66,25 @@ class TD2_Reynolds_Correction(LossBaseClass):
     def LossType(self):
         return self._loss_type
     
-    def __call__(self,upstream:BladeRow, row:BladeRow) -> npt.NDArray:
+    def __call__(self,row:BladeRow, upstream:BladeRow) -> npt.NDArray:
         """Apply TD2 Reynolds correction (NASA SP-290 Vol.1, p.62).
-    
+
         The correction follows td2-2.f line 2771:
         WYECOR = WYECOR*(0.35+0.65*18.21)/(0.35+0.65*(FLWP/VISC/RST(MEAN))**0.2)
 
         Args:
-            upstream (BladeRow): Upstream blade row supplying inlet conditions.
             row (BladeRow): Blade row receiving the correction.
-        
+            upstream (BladeRow): Upstream blade row supplying inlet conditions.
+
         Returns:
             numpy.ndarray: Reynolds-corrected total pressure loss coefficient.
         """
-        Y = self.TD2(upstream,row)
-        A = 0.35
-        B = 0.65
-        Y = Y * (A+B*18.21)/(0.35+0.65*row.massflow/(row.mu* row.r.mean()))
+        Y = self.TD2(row, upstream)
+        # Reynolds group massflow/(mu * r_mean) is dimensionless and corresponds to
+        # FLWP/VISC/RST(MEAN) in td2-2.f. The legacy 0.2 turbulent exponent was dropped
+        # in the original Python port and is restored here.
+        Re_group = row.massflow / (row.mu * row.r.mean())
+        Y = Y * (0.35 + 0.65*18.21) / (0.35 + 0.65*Re_group**0.2)
         row.Yp = Y
         return Y
     

--- a/turbodesign/loss/turbine/kackerokapuu.py
+++ b/turbodesign/loss/turbine/kackerokapuu.py
@@ -105,7 +105,15 @@ class KackerOkapuu(LossBaseClass):
         if M1>=0.4: # You'll have imaginary numbers if M1<0.4
             dP_q1_hub = 0.75*(M1-0.4)**1.75 # Eqn 4, this is at the hub
             dP_q1_shock = row.r[-1]/row.r[0] * dP_q1_hub # Eqn 5
-            Y_shock = dP_q1_shock * upstream.P/row.P * (1-(1+(upstream.gamma-1)/2*M1**2))/(1-(1+(row.gamma-1)/2*M2**2)) # Eqn 6
+            # Eqn 6: convert the inlet-q shock loss to the exit dynamic-head basis using the
+            # isentropic dynamic-head fraction q/P0 = 1 - (1 + (gamma-1)/2 M^2)^(-gamma/(gamma-1)).
+            # The (-gamma/(gamma-1)) exponent was dropped in the original port and is restored
+            # here (cf. the trailing-edge denominator below, which uses it correctly). The
+            # spurious static-pressure ratio P1/P2 is removed: the q/P0 terms already carry the
+            # per-row total-pressure normalization, so the conversion is the q1/q2 ratio.
+            q1_frac = 1-(1+(upstream.gamma-1)/2*M1**2)**(-upstream.gamma/(upstream.gamma-1))
+            q2_frac = 1-(1+(row.gamma-1)/2*M2**2)**(-row.gamma/(row.gamma-1))
+            Y_shock = dP_q1_shock * q1_frac/q2_frac # Eqn 6
             Y_shock = _mean_value(Y_shock)
         else:
             Y_shock = 0


### PR DESCRIPTION
## Summary

Two turbine loss correlations dropped an exponent when ported from their legacy Fortran/paper formulae. In each case the missing exponent collapses the intended term into something qualitatively different.

### 1. `TD2_Reynolds_Correction` — `loss/turbine/TD2.py`

The docstring quotes the source formula from `td2-2.f` line 2771:

```
WYECOR = WYECOR*(0.35+0.65*18.21)/(0.35+0.65*(FLWP/VISC/RST(MEAN))**0.2)
```

but the implementation omitted the `**0.2`:

```python
Y = Y * (A+B*18.21)/(0.35+0.65*row.massflow/(row.mu* row.r.mean()))
```

Without the exponent the correction reduces to a linear Reynolds group instead of the intended `Re**0.2` turbulent scaling (NASA SP-290 Vol. 1, p. 62). `0.2` is also the standard turbulent Reynolds exponent used elsewhere (e.g. Kacker–Okapuu's high-Re branch already uses `(Re/1e6)**-0.2` in this repo).

**Also:** the method signature was `(self, upstream, row)`, opposite to the `LossBaseClass` contract `(self, row, upstream)` that every other loss model follows. Since the spool always calls `loss(row, upstream)`, the reversed signature meant the Reynolds group (`row.massflow/(row.mu*row.r.mean())`) and the `row.Yp = Y` side-effect were evaluated against the **upstream** row rather than the row being corrected. Standardizing the signature fixes both the Liskov hazard and which row's properties drive the correction.

### 2. Kacker–Okapuu shock loss (Eqn 6) — `loss/turbine/kackerokapuu.py`

```python
Y_shock = dP_q1_shock * upstream.P/row.P * (1-(1+(upstream.gamma-1)/2*M1**2))/(1-(1+(row.gamma-1)/2*M2**2))
```

K&O Eq 6 converts the inlet-`q` shock loss to the exit dynamic-head basis with the isentropic dynamic-head fraction:

```
q/P0 = 1 - (1 + (gamma-1)/2 * M^2)^(-gamma/(gamma-1))
```

The `^(-gamma/(gamma-1))` exponent was dropped. Without it, `1 - (1 + (gamma-1)/2*M^2)` collapses to `-(gamma-1)/2*M^2`, so the whole term degenerates into a static-pressure ratio times `M1^2/M2^2` rather than the intended dynamic-head ratio. The same dynamic-head fraction is already used **correctly** for the trailing-edge loss denominator a few lines below, so this is an internal inconsistency. The spurious static-pressure ratio `P1/P2` is also removed — the per-row `q/P0` terms already carry the total-pressure normalization, leaving the conversion as the `q1/q2` ratio.

## Sources

- Glassman, A. J. (ed.), *Turbine Design and Application*, NASA SP-290 Vol. 1 (1972), Reynolds correction p. 62; `td2-2.f` line 2771 (cited in the existing docstring).
- Kacker, S. C., and Okapuu, U., 1982, *ASME J. Eng. Power* 104(1), pp. 111–119 (Paper 81-GT-58), shock loss Eqs. 4–6, p. 113.
- Isentropic dynamic-head relation `q/p0 = 1 - (1+(γ-1)/2 M²)^(-γ/(γ-1))` — standard compressible flow (e.g. Anderson, *Modern Compressible Flow*, Ch. 3).

## Testing

These are off-by-an-exponent corrections; the modules compile and the changes are localized to the two correlations. I do not have a validated turbine case bundled to assert numeric deltas — happy to add a regression test if the maintainers point me at a reference case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
