### PR TITLE
Restore shared Cantera Solution state in compute_gas_constants

### DIFF
--- a/turbodesign/bladerow.py
+++ b/turbodesign/bladerow.py
@@ -880,9 +880,17 @@ def compute_gas_constants(row:BladeRow,fluid:Optional[Solution]=None) -> None:
     if fluid:
         Tm = row.T.mean()
         Pm = row.P.mean()
-        fluid.TP = Tm,Pm
-        row.Cp = fluid.cp
-        row.Cv = fluid.cv
+        # A single ct.Solution is shared across all blade rows (TurbineSpool/CompressorSpool
+        # assign br.fluid = self._fluid), so mutating it in place leaks this row's (T,P) into
+        # any later property read on the shared object. Snapshot and restore the state around
+        # the read so the shared Solution is left untouched.
+        _saved_state = fluid.state
+        try:
+            fluid.TP = Tm,Pm
+            row.Cp = fluid.cp
+            row.Cv = fluid.cv
+        finally:
+            fluid.state = _saved_state
         row.R = row.Cp-row.Cv
         row.gamma = row.Cp/row.Cv
     # Use Ideal Gas 


### PR DESCRIPTION
## Summary

`compute_gas_constants` (`turbodesign/bladerow.py`) mutates a Cantera `Solution` in place to read `cp`/`cv`:

```python
fluid.TP = Tm, Pm
row.Cp = fluid.cp
row.Cv = fluid.cv
```

Both `TurbineSpool` and `CompressorSpool` assign **one shared** `Solution` to every blade row (`br.fluid = self._fluid`), and `compute_gas_constants` is called repeatedly with that same object. Each call leaves the shared `Solution` at the last row's `(T, P)`, so any property read on the shared object *between* calls reflects the wrong row's state.

This snapshots the state and restores it in a `finally` block:

```python
_saved_state = fluid.state
try:
    fluid.TP = Tm, Pm
    row.Cp = fluid.cp
    row.Cv = fluid.cv
finally:
    fluid.state = _saved_state
```

The read still happens at this row's `(T, P)`, so the `cp`/`cv`/`gamma` this function computes are unchanged; the shared `Solution` is simply left exactly as it was found. `fluid.state` is Cantera's documented snapshot/restore mechanism for a phase's thermodynamic state.

This is defensive hardening — `compute_gas_constants` re-sets `TP` before each read, so it is self-correcting for its own use; the exposure is any other reader of the shared `Solution` in between. Cheap insurance against a class of silent cross-row corruption.

## Sources

- Cantera `ThermoPhase.state` save/restore idiom (Cantera Python API).

## Testing

Module compiles; the change is a save/restore wrapper around an existing read with no change to computed outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
