### PR TITLE
fix(compressor): a rotor with zero loss that destroys entropy, and seven other defects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: tests
+on: [push, pull_request]
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pytest
+      - name: Run tests
+        run: pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ plot3d = "*"
 numpy = "*"
 scipy = "*"
 findiff = "*"
+# turbodesign/loss/turbine/{craigcox,traupel,ainleymathieson,kackerokapuu}.py all
+# `import requests` at module scope, but it was never declared: a clean `pip install
+# turbo-design` yields a package that raises ImportError on those four loss models.
+# It goes unnoticed because requests is present transitively in most environments.
+requests = "*"
 matplotlib = "*"
 pandas = "*"
 python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,17 @@ shapely = "*"
 [poetry.group.dev.dependencies]
 python = ">=3.12"
 
+# NOTE: the table above is missing the "tool." prefix, so Poetry does not read it as a
+# dependency group. Left as it is: correcting it would change dependency resolution, which
+# is outside the scope of a change that adds tests.
+[tool.poetry.group.dev.dependencies]
+pytest = ">=8.0"
+
 [build-system]
 requires = ["poetry>=1.1.2"]
-build-backend = "poetry.masonry.api"    
+build-backend = "poetry.masonry.api"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: takes multiple seconds (e.g. runs an optimizer-driven example); deselect with '-m \"not slow\"'",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+# tests/conftest.py
+"""Load a converged spool from a real example, without editing the example.
+
+Most example scripts wrap their work in a `main()` that returns None. Rather than fork a
+copy of their setup into the test suite -- which would let the fixture and the example
+drift apart -- we parse the real file and append `return locals()` to main() in the AST.
+The file on disk is never modified.
+
+A few examples (e.g. `EEE-HPT/eee_hpt.py`, `radial-turbine/radial_turbine-1D.py`) are
+flat top-level scripts with no `main()` at all. For those there is nothing to patch: the
+module's own top-level namespace, after exec, already *is* the converged state, so it is
+returned directly.
+
+Several examples write their results (JSON, PNG, pickles) to a path built from `__file__`
+-- an absolute path inside `examples/` -- so simply running one overwrites files in the
+working tree, including any uncommitted edit a contributor has in that directory. Each
+example is therefore copied into a scratch directory and the copy is what runs: `__file__`,
+`sys.path` and the working directory all point into the copy. The repository is never
+written to, so there is nothing to restore afterwards.
+"""
+
+import ast
+import contextlib
+import io
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import matplotlib
+
+# A couple of examples call plt.show()/savefig(). Force a non-interactive backend before
+# anything else has a chance to import pyplot, so running the suite never pops a GUI
+# window or blocks.
+matplotlib.use("Agg", force=True)
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = REPO_ROOT / "examples"
+
+
+def _patch_main_to_return_locals(tree: ast.Module) -> bool:
+    """Append `return locals()` to a top-level `main()`. True if there was one."""
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            node.body.append(
+                ast.Return(
+                    value=ast.Call(
+                        func=ast.Name(id="locals", ctx=ast.Load()), args=[], keywords=[]
+                    )
+                )
+            )
+            ast.fix_missing_locations(tree)
+            return True
+    return False
+
+
+def _run(path: Path) -> dict:
+    """Run one example inside a private copy of its directory; return its namespace.
+
+    `path` points at the example in the repository. The example's whole directory is
+    copied to a scratch location and the copy is executed, so the data files the example
+    reads are all present and anything it writes lands in the copy.
+    """
+    sandbox = Path(tempfile.mkdtemp(prefix="turbo-design-example-"))
+    try:
+        example_dir = sandbox / path.parent.name
+        shutil.copytree(path.parent, example_dir)
+        script = example_dir / path.name
+
+        tree = ast.parse(script.read_text(), filename=str(script))
+        has_main = _patch_main_to_return_locals(tree)
+
+        ns: dict = {"__name__": "__characterization__", "__file__": str(script)}
+        # EEE-HPT's script does `from get_ss_ps import ...` -- a bare top-level import of
+        # a sibling file. That resolves automatically only when the interpreter is
+        # launched as `python eee_hpt.py`, which prepends the script's own directory to
+        # sys.path; exec() here does not do that for us.
+        sys.path.insert(0, str(example_dir))
+        cwd_before = os.getcwd()
+        os.chdir(example_dir)
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                exec(compile(tree, str(script), "exec"), ns)
+                # `__name__` is not "__main__", so an example guarded by
+                # `if __name__ == "__main__": main()` has defined main() but not run it.
+                return ns["main"]() if has_main else ns
+        finally:
+            os.chdir(cwd_before)
+            sys.path.remove(str(example_dir))
+    finally:
+        shutil.rmtree(sandbox, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def example_spool():
+    """Run an example once per session and return its converged namespace.
+
+    `name` is a path relative to `examples/`, e.g.
+    "mattingly-axial-compressor/example9.1.py" or "EEE-HPT/eee_hpt.py".
+    """
+    cache: dict = {}
+
+    def _load(name: str) -> dict:
+        if name not in cache:
+            cache[name] = _run(EXAMPLES / name)
+        return cache[name]
+
+    return _load

--- a/tests/test_axial_characterization.py
+++ b/tests/test_axial_characterization.py
@@ -24,59 +24,59 @@ def test_example_9_1_is_three_streamlines(example_spool):
 def test_example_9_1_overall(example_spool):
     spool = example_spool("mattingly-axial-compressor/example9.1.py")["spool"]
     assert spool.massflow == pytest.approx(22.6796, rel=RTOL)
-    assert spool.overall_pressure_ratio() == pytest.approx(1.3360587343032544, rel=RTOL)
+    assert spool.overall_pressure_ratio() == pytest.approx(1.3341973512851182, rel=RTOL)
 
 
 def test_example_9_1_rotor_per_streamline(example_spool):
     rotor = example_spool("mattingly-axial-compressor/example9.1.py")["rotor"]
     assert rotor.r == pytest.approx([0.274612394592, 0.3048, 0.334987605408], rel=RTOL)
     assert rotor.P0 == pytest.approx(
-        [118723.70502439793, 135158.28238870634, 147801.11230809323], rel=RTOL
+        [119628.39581103637, 134654.9438487545, 145123.1800222211], rel=RTOL
     )
     assert rotor.T0 == pytest.approx(
-        [302.717182747679, 312.798819587163, 319.179654224343], rel=RTOL
+        [302.2099828302515, 312.6535100310146, 319.4447100979148], rel=RTOL
     )
     assert rotor.P0R == pytest.approx(
-        [100109.87642584258, 106221.6927355795, 105585.90931530058], rel=RTOL
+        [101472.6344434061, 106007.01485885675, 103382.93537587197], rel=RTOL
     )
     assert rotor.T0R == pytest.approx(
-        [288.256792735336, 291.899539873286, 289.806659750478], rel=RTOL
+        [288.26368910588, 291.906523697345, 289.8136025909995], rel=RTOL
     )
     assert rotor.M == pytest.approx(
-        [0.82329899123, 0.882171122458, 0.947232789356], rel=RTOL
+        [0.8300588723044268, 0.8836656583201487, 0.9454459831924451], rel=RTOL
     )
     assert rotor.M_rel == pytest.approx(
-        [0.638851397703, 0.627935526295, 0.597910853155], rel=RTOL
+        [0.6541796871156736, 0.6319799253120101, 0.5917376972636], rel=RTOL
     )
 
 
 def test_example_9_1_stator_per_streamline(example_spool):
     stator = example_spool("mattingly-axial-compressor/example9.1.py")["stator"]
     assert stator.P0 == pytest.approx(
-        [122755.33113047821, 135108.6406580774, 148376.59867602392], rel=RTOL
+        [124686.40724035529, 135017.66232236876, 145970.53079910018], rel=RTOL
     )
     assert stator.M == pytest.approx(
-        [0.586561267717, 0.670423034066, 0.740061151736], rel=RTOL
+        [0.6092420162196824, 0.6720905746225406, 0.7269550972159657], rel=RTOL
     )
 
 
 def test_example_9_2_overall(example_spool):
     spool = example_spool("mattingly-axial-compressor/example9.2.py")["spool"]
     assert spool.massflow == pytest.approx(22.68, rel=RTOL)
-    assert spool.overall_pressure_ratio() == pytest.approx(1.292878358443007, rel=RTOL)
+    assert spool.overall_pressure_ratio() == pytest.approx(1.2911654599889533, rel=RTOL)
 
 
 def test_example_9_2_rotor_per_streamline(example_spool):
     rotor = example_spool("mattingly-axial-compressor/example9.2.py")["rotor"]
     assert rotor.r == pytest.approx([0.273978687961, 0.3048, 0.335621312039], rel=RTOL)
     assert rotor.P0R == pytest.approx(
-        [97543.68041388667, 103111.38595056451, 102563.81089289424], rel=RTOL
+        [98740.66209918521, 102918.64302259442, 100612.03719717609], rel=RTOL
     )
     assert rotor.T0R == pytest.approx(
-        [288.045210087425, 291.849742618825, 289.967113368956], rel=RTOL
+        [288.05267532349905, 291.8572966174646, 289.97433510707276], rel=RTOL
     )
     assert rotor.M_rel == pytest.approx(
-        [0.650202734506, 0.636853067701, 0.605750066296], rel=RTOL
+        [0.6644041789821085, 0.6407581013471035, 0.6002922414935745], rel=RTOL
     )
 
 

--- a/tests/test_axial_characterization.py
+++ b/tests/test_axial_characterization.py
@@ -1,0 +1,112 @@
+# tests/test_axial_characterization.py
+"""Pin the current behaviour of the axial compressor examples.
+
+These are characterization goldens: they record what the code does today, not what is
+physically correct. Several are expected to move when known defects are fixed; the point of
+pinning them is that the change is then visible and has to be stated.
+
+Pinned per streamline (hub, mean, shroud). Both examples run num_streamlines = 3, the
+CompressorSpool default. A meanline-only golden would be blind to any defect whose error
+vanishes at constant radius -- and both examples hold the mean radius constant.
+"""
+
+import numpy as np
+import pytest
+
+RTOL = 1e-9
+
+
+def test_example_9_1_is_three_streamlines(example_spool):
+    spool = example_spool("mattingly-axial-compressor/example9.1.py")["spool"]
+    assert spool.num_streamlines == 3
+
+
+def test_example_9_1_overall(example_spool):
+    spool = example_spool("mattingly-axial-compressor/example9.1.py")["spool"]
+    assert spool.massflow == pytest.approx(22.6796, rel=RTOL)
+    assert spool.overall_pressure_ratio() == pytest.approx(1.3360587343032544, rel=RTOL)
+
+
+def test_example_9_1_rotor_per_streamline(example_spool):
+    rotor = example_spool("mattingly-axial-compressor/example9.1.py")["rotor"]
+    assert rotor.r == pytest.approx([0.274612394592, 0.3048, 0.334987605408], rel=RTOL)
+    assert rotor.P0 == pytest.approx(
+        [118723.70502439793, 135158.28238870634, 147801.11230809323], rel=RTOL
+    )
+    assert rotor.T0 == pytest.approx(
+        [302.717182747679, 312.798819587163, 319.179654224343], rel=RTOL
+    )
+    assert rotor.P0R == pytest.approx(
+        [100109.87642584258, 106221.6927355795, 105585.90931530058], rel=RTOL
+    )
+    assert rotor.T0R == pytest.approx(
+        [288.256792735336, 291.899539873286, 289.806659750478], rel=RTOL
+    )
+    assert rotor.M == pytest.approx(
+        [0.82329899123, 0.882171122458, 0.947232789356], rel=RTOL
+    )
+    assert rotor.M_rel == pytest.approx(
+        [0.638851397703, 0.627935526295, 0.597910853155], rel=RTOL
+    )
+
+
+def test_example_9_1_stator_per_streamline(example_spool):
+    stator = example_spool("mattingly-axial-compressor/example9.1.py")["stator"]
+    assert stator.P0 == pytest.approx(
+        [122755.33113047821, 135108.6406580774, 148376.59867602392], rel=RTOL
+    )
+    assert stator.M == pytest.approx(
+        [0.586561267717, 0.670423034066, 0.740061151736], rel=RTOL
+    )
+
+
+def test_example_9_2_overall(example_spool):
+    spool = example_spool("mattingly-axial-compressor/example9.2.py")["spool"]
+    assert spool.massflow == pytest.approx(22.68, rel=RTOL)
+    assert spool.overall_pressure_ratio() == pytest.approx(1.292878358443007, rel=RTOL)
+
+
+def test_example_9_2_rotor_per_streamline(example_spool):
+    rotor = example_spool("mattingly-axial-compressor/example9.2.py")["rotor"]
+    assert rotor.r == pytest.approx([0.273978687961, 0.3048, 0.335621312039], rel=RTOL)
+    assert rotor.P0R == pytest.approx(
+        [97543.68041388667, 103111.38595056451, 102563.81089289424], rel=RTOL
+    )
+    assert rotor.T0R == pytest.approx(
+        [288.045210087425, 291.849742618825, 289.967113368956], rel=RTOL
+    )
+    assert rotor.M_rel == pytest.approx(
+        [0.650202734506, 0.636853067701, 0.605750066296], rel=RTOL
+    )
+
+
+def test_the_annulus_contracts_off_the_meanline(example_spool):
+    """What the per-streamline pin above is for.
+
+    Both examples hold the mean radius constant while contracting the annulus, so r2/r1 is
+    exactly 1.000 at the mean and differs from 1 at hub and shroud. Any error that scales
+    with (U2 - U1) is therefore absent from the meanline and present only off it.
+    """
+    for name in (
+        "mattingly-axial-compressor/example9.1.py",
+        "mattingly-axial-compressor/example9.2.py",
+    ):
+        loc = example_spool(name)
+        inlet, rotor = loc["spool"].blade_rows[0], loc["rotor"]
+        ratio = np.asarray(rotor.r, float) / np.asarray(inlet.r, float)
+        assert ratio[1] == pytest.approx(1.0, abs=1e-12), f"{name}: mean radius moved"
+        assert abs(ratio[0] - 1.0) > 1e-3, f"{name}: hub does not contract"
+        assert abs(ratio[2] - 1.0) > 1e-3, f"{name}: shroud does not contract"
+
+
+def test_the_examples_are_deterministic(example_spool):
+    """If the baseline does not reproduce bit for bit, nothing pinned above means anything."""
+    from tests.conftest import EXAMPLES, _run
+
+    a = _run(EXAMPLES / "mattingly-axial-compressor" / "example9.1.py")[
+        "spool"
+    ].overall_pressure_ratio()
+    b = _run(EXAMPLES / "mattingly-axial-compressor" / "example9.1.py")[
+        "spool"
+    ].overall_pressure_ratio()
+    assert a == b

--- a/tests/test_band_area_oracle.py
+++ b/tests/test_band_area_oracle.py
@@ -1,0 +1,165 @@
+# tests/test_band_area_oracle.py
+"""The streamtube band area, checked against geometry rather than against the library.
+
+This module does not import turbodesign. It is an independent oracle: a code that agrees
+with itself is not validated.
+
+The band swept by a straight meridional segment revolved about the machine axis is the
+lateral surface of a conical frustum. By Pappus's centroid theorem,
+
+    A = 2*pi*r_centroid*L = pi*(r1 + r2)*sqrt(dx**2 + dr**2)
+
+which reduces to pi*(r2**2 - r1**2) at dx = 0 (an annulus) and to 2*pi*r*b at dr = 0 (a
+cylinder). One formula, valid at any meridional angle.
+"""
+
+import numpy as np
+import pytest
+from scipy.integrate import quad
+
+
+def buggy_band_area(x1, r1, x2, r2):
+    """Verbatim reproduction of flow_math.py:40 (upstream 4018a6c).
+
+    S is a length in metres, so S/2 * dx**2 is a cubic metre, and it is added to r1*dx,
+    a square metre. tests/test_current_area_formula.py checks that this reproduction still
+    matches the library.
+    """
+    dx = x2 - x1
+    S = r2 - r1  # metres -- not a slope
+    C = np.sqrt(1.0 + ((r2 - r1) / dx) ** 2)
+    return 2 * np.pi * C * (S / 2 * dx**2 + r1 * dx)
+
+
+def buggy_branching_area(x1, r1, x2, r2):
+    """Verbatim reproduction of the branch guard at flow_math.py:32 (upstream 4018a6c):
+    below the 1e-5 threshold on dx, the annulus formula pi*(r2**2 - r1**2); at or above
+    it, buggy_band_area. Reproduced branch and all, so the test below exercises the actual
+    discontinuity rather than a formula that resembles it.
+    """
+    dx = x2 - x1
+    if np.abs(dx) < 1e-5:
+        return np.pi * (r2**2 - r1**2)
+    return buggy_band_area(x1, r1, x2, r2)
+
+
+def pappus_band_area(x1, r1, x2, r2):
+    return np.pi * (r1 + r2) * np.hypot(x2 - x1, r2 - r1)
+
+
+def slope_variant_band_area(x1, r1, x2, r2):
+    """The obvious repair to buggy_band_area: redefine S as the slope dr/dx rather than a
+    length, leaving C and everything else unchanged. It fixes the dimensional error but
+    not the sign, which is what test_area_is_never_negative_for_a_reversed_cut measures.
+    """
+    dx = x2 - x1
+    S = (r2 - r1) / dx  # a slope now, not metres
+    C = np.sqrt(1.0 + ((r2 - r1) / dx) ** 2)
+    return 2 * np.pi * C * (S / 2 * dx**2 + r1 * dx)
+
+
+def quadrature_band_area(x1, r1, x2, r2):
+    """A second implementation of the same surface-of-revolution integral, evaluated
+    numerically rather than through Pappus's closed form. For a straight-line generatrix --
+    the only case this file exercises -- that closed form is this integral; the two are
+    independent implementations of one theorem, not two theorems (see
+    test_pappus_agrees_with_quadrature_on_a_cone).
+    """
+    dx, dr = x2 - x1, r2 - r1
+    speed = np.hypot(dx, dr)
+    val, _ = quad(
+        lambda t: 2 * np.pi * (r1 + t * dr) * speed,
+        0.0,
+        1.0,
+        epsabs=1e-14,
+        epsrel=1e-14,
+    )
+    return float(val)
+
+
+def test_pappus_agrees_with_quadrature_on_a_cone():
+    """Two independent implementations, agreeing to machine precision -- not two
+    independent theorems. For a straight-line generatrix, Pappus's centroid theorem is the
+    closed form of the exact integral quadrature_band_area evaluates numerically; they are
+    provably the same quantity, computed two ways. The cross-check catches a typo in either
+    implementation (a wrong centroid, a missing factor of 2, wrong bounds, a transposed
+    r1/r2). It would not catch an error shared by both -- a wrong definition of the surface
+    itself -- because for this shape there is only one integral to get right.
+    """
+    a = pappus_band_area(0.0, 0.25, 0.10, 0.35)
+    b = quadrature_band_area(0.0, 0.25, 0.10, 0.35)
+    assert a == pytest.approx(b, rel=1e-12)
+
+
+def test_a_cylinder_does_not_discriminate():
+    """With dr = 0 the buggy formula is exact, so a cylinder passes against it. Any check
+    of the area formula that uses one establishes nothing.
+    """
+    args = (0.0, 0.2, 0.05, 0.2)
+    assert buggy_band_area(*args) == pytest.approx(pappus_band_area(*args), rel=1e-12)
+    assert pappus_band_area(*args) == pytest.approx(2 * np.pi * 0.2 * 0.05, rel=1e-12)
+
+
+def test_a_cone_discriminates():
+    """The discriminating case: a sloped endwall, 0.25 -> 0.35 in radius over 0.10 axial.
+    The buggy formula under-reports the area by more than 10%.
+    """
+    args = (0.0, 0.25, 0.10, 0.35)
+    err = (buggy_band_area(*args) - pappus_band_area(*args)) / pappus_band_area(*args)
+    assert err < -0.10, (
+        f"expected the bug to under-report by more than 10%, got {err:.2%}"
+    )
+
+
+def test_pappus_reduces_to_the_annulus_when_dx_is_zero():
+    a = pappus_band_area(0.0, 0.25, 0.0, 0.35)
+    assert a == pytest.approx(np.pi * (0.35**2 - 0.25**2), rel=1e-12)
+
+
+def test_pappus_is_continuous_across_the_branch_guard():
+    """flow_math.py:32 guards on abs(dx) < 1e-5 -- on dx, not on the meridional angle. A
+    2-micron change in a coordinate (9e-6 -> 1.1e-5) crosses the guard and switches formula:
+    the annulus pi*(r2**2 - r1**2) below the threshold, buggy_band_area at or above it. That
+    switch moves the result by about -16.7%. Pappus, built from hypot and multiplication, is
+    continuous, and moves by about 2e-9 relative.
+    """
+    x1, r1, r2 = 0.0, 0.25, 0.35
+    below = buggy_branching_area(x1, r1, 9e-6, r2)
+    above = buggy_branching_area(x1, r1, 1.1e-5, r2)
+    cliff = (above - below) / below
+    assert cliff < -0.15, (
+        f"expected the branch guard to produce a double-digit-percent jump for a "
+        f"2-micron change in dx, got {cliff:.2%}"
+    )
+
+    p_below = pappus_band_area(x1, r1, 9e-6, r2)
+    p_above = pappus_band_area(x1, r1, 1.1e-5, r2)
+    p_change = (p_above - p_below) / p_below
+    assert abs(p_change) < 1e-6, (
+        f"Pappus should be continuous across the guard; got a relative change of "
+        f"{p_change:.2e}"
+    )
+
+
+def test_area_is_never_negative_for_a_reversed_cut():
+    """Pappus cannot go negative: hypot is unsigned, so a reversed cut (decreasing x) gives
+    the same area as the forward cut. The slope-variant repair of buggy_band_area is not so
+    lucky: C*dx = sign(dx)*L, so a cut ordered with decreasing x flips its sign. Measured
+    below, and it is the reason to delete the branch rather than patch S.
+    """
+    forward = pappus_band_area(0.0, 0.25, 0.10, 0.35)
+    backward = pappus_band_area(0.10, 0.35, 0.0, 0.25)
+    assert forward > 0 and backward > 0
+    assert forward == pytest.approx(backward, rel=1e-12)
+
+    slope_forward = slope_variant_band_area(0.0, 0.25, 0.10, 0.35)
+    slope_backward = slope_variant_band_area(0.10, 0.35, 0.0, 0.25)
+    # The dimensional half of the repair is right: the forward magnitude matches Pappus.
+    assert slope_forward == pytest.approx(forward, rel=1e-12)
+    # The sign half is not: the reversed cut returns a negative area, which Pappus -- and
+    # an area -- cannot.
+    assert slope_backward < 0, (
+        f"expected the slope-variant repair to still yield a negative area on a "
+        f"reversed cut, got {slope_backward}"
+    )
+    assert slope_backward == pytest.approx(-forward, rel=1e-12)

--- a/tests/test_bracket_convergence.py
+++ b/tests/test_bracket_convergence.py
@@ -1,0 +1,97 @@
+# tests/test_bracket_convergence.py
+"""compressor_math.py solves for the rotor exit relative Mach number with
+
+    minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+
+`method="bounded"` cannot leave its bracket. A transonic axial fan or
+front-stage compressor rotor can legitimately demand more massflow at a
+given area/speed/pressure than is achievable at any relative Mach <= 1 --
+the mass-flux-vs-Mach relation peaks at M=1 and falls off beyond it, so the
+bounded search has nowhere left to go but the M=1 edge. It parks there,
+`res.success` is `True`, and the unmatched massflow residual is silently
+swallowed: the caller applies M_rel = 1 as though it were the converged
+answer.
+
+This file proves both directions of the fix:
+  * a rotor whose true mass-flow-matching Mach sits well inside [0.01, 1]
+    still solves normally, unchanged;
+  * a rotor driven with a massflow demand the passage cannot support at any
+    Mach <= 1 must raise instead of silently returning the M=1 edge.
+"""
+
+import numpy as np
+import pytest
+
+from turbodesign.bladerow import BladeRow
+from turbodesign.enums import RowType
+from turbodesign.loss.fixedpressureloss import FixedPressureLoss
+from turbodesign.compressor_math import rotor_calc
+
+
+def _make_upstream(total_massflow: float) -> BladeRow:
+    """A converged upstream row feeding the rotor (meanline, one streamline)."""
+    row = BladeRow(
+        row_type=RowType.Stator,
+        r=np.array([0.3048]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+    )
+    row.rpm = 9549.297  # omega = rpm*pi/30 = 1000 rad/s
+    row.Vx = np.array([200.0])
+    row.Vt = np.array([150.0])
+    row.Vr = np.array([0.0])
+    row.Vm = np.array([200.0])
+    row.T = np.array([288.0])
+    row.P = np.array([90000.0])
+    row.P0 = np.array([101325.0])
+    row.total_massflow = total_massflow
+    return row
+
+
+def _make_rotor(total_area: float) -> BladeRow:
+    """A rotor row with a small fixed exit area, so massflow demand can be
+    pushed past what is achievable at relative Mach <= 1."""
+    row = BladeRow(
+        row_type=RowType.Rotor,
+        r=np.array([0.3048]),
+        phi=np.array([0.0]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+        omega=1000.0,
+        total_area=total_area,
+        P0_ratio=1.15,
+        loss_function=FixedPressureLoss(0.0),
+    )
+    row.metal_exit_angle = [-30.0]
+    return row
+
+
+def test_rotor_relative_mach_inside_bracket_solves_unchanged():
+    """A modest massflow demand has its matching Mach well inside [0.01, 1]."""
+    upstream = _make_upstream(total_massflow=8.0)
+    row = _make_rotor(total_area=0.05)
+
+    rotor_calc(row, upstream, calculate_vm=True)
+
+    assert 0.01 < row.M_rel[0] < 0.99
+    assert row.M_rel[0] == pytest.approx(0.4006, abs=1e-3)
+
+
+def test_rotor_relative_mach_outside_bracket_raises_instead_of_pinning():
+    """Push the massflow demand past what this area can pass at M_rel <= 1.
+
+    Pre-fix, this silently returns M_rel pinned at the 1.0 edge of the
+    bounded search, `res.success == True`, with a several-kg/s unmatched
+    massflow residual that nothing surfaces. That is exactly the transonic
+    condition described in the module docstring above: the true
+    mass-flow-matching state is not reachable inside the bracket, so the
+    bounded optimizer has nowhere to go but the edge. Post-fix this must
+    raise instead of returning that edge value as though it were converged.
+    """
+    upstream = _make_upstream(total_massflow=15.0)
+    row = _make_rotor(total_area=0.05)
+
+    with pytest.raises(RuntimeError, match="relative Mach"):
+        rotor_calc(row, upstream, calculate_vm=True)

--- a/tests/test_bracket_convergence.py
+++ b/tests/test_bracket_convergence.py
@@ -25,7 +25,7 @@ import pytest
 from turbodesign.bladerow import BladeRow
 from turbodesign.enums import RowType
 from turbodesign.loss.fixedpressureloss import FixedPressureLoss
-from turbodesign.compressor_math import rotor_calc
+from turbodesign.compressor_math import _solve_bounded, rotor_calc
 
 
 def _make_upstream(total_massflow: float) -> BladeRow:
@@ -95,3 +95,54 @@ def test_rotor_relative_mach_outside_bracket_raises_instead_of_pinning():
 
     with pytest.raises(RuntimeError, match="relative Mach"):
         rotor_calc(row, upstream, calculate_vm=True)
+
+
+# --- _solve_bounded bound semantics -----------------------------------------
+#
+# A loss coefficient Yp searched over [0.0, 0.95] is a different kind of
+# bracket than a Mach number searched over [0.01, 1]: 0.0 is not an arbitrary
+# search limit, it is the physical floor of a pressure-loss coefficient (a row
+# cannot have negative loss), so an optimum sitting there is a legitimate,
+# fully-converged, lossless answer. The upper edge 0.95 has no such physical
+# meaning -- it is just a numerical ceiling -- so an optimum parked there
+# still means "the target could not be reached inside the bracket" and must
+# still raise. The two bounds of the same bracket are not interchangeable.
+
+
+def test_solve_bounded_yp_zero_is_a_valid_lossless_answer():
+    """The optimum sits exactly on the lower (physical) edge of a Yp bracket.
+
+    That lower edge must NOT be guarded for a loss coefficient: Yp = 0 is a
+    real, physically-allowed answer (a lossless row), not a sign that the
+    search ran out of room.
+    """
+    res = _solve_bounded(
+        lambda y: abs(y - 0.0), [0.0, 0.95], "rotor Yp", check_lower=False
+    )
+    assert res.x == pytest.approx(0.0, abs=1e-3)
+
+
+def test_solve_bounded_yp_above_ceiling_still_raises():
+    """The optimum lies above the 0.95 ceiling of a Yp bracket.
+
+    Even with the lower edge unguarded, the upper edge is still an arbitrary
+    numerical ceiling: parking on it means the target loss/efficiency could
+    not be matched inside the bracket, so this must still raise.
+    """
+    with pytest.raises(RuntimeError, match="Yp"):
+        _solve_bounded(
+            lambda y: abs(y - 1.5), [0.0, 0.95], "rotor Yp", check_lower=False
+        )
+
+
+def test_solve_bounded_mach_lower_edge_still_raises():
+    """Mach brackets are unchanged: both edges of [0.01, 1] remain arbitrary
+    numerical limits, not physical answers, so both must still raise."""
+    with pytest.raises(RuntimeError, match="Mach"):
+        _solve_bounded(lambda m: abs(m - 0.01), [0.01, 1], "test Mach")
+
+
+def test_solve_bounded_mach_upper_edge_still_raises():
+    """Same as above, for the upper edge (the supersonic side)."""
+    with pytest.raises(RuntimeError, match="Mach"):
+        _solve_bounded(lambda m: abs(m - 1.0), [0.01, 1], "test Mach")

--- a/tests/test_current_area_formula.py
+++ b/tests/test_current_area_formula.py
@@ -1,0 +1,58 @@
+# tests/test_current_area_formula.py
+"""Tie the reproduction in test_band_area_oracle.py to the library it reproduces.
+
+test_band_area_oracle.py deliberately does not import turbodesign: it is an oracle, and it
+has to be able to disagree with the library. The cost of that is a copy of flow_math.py's
+band-area expression sitting in the test suite with nothing holding the two together. Once
+the formula in the library changes, the copy becomes a stale reproduction of a formula that
+no longer exists, and the oracle's tests keep passing while asserting nothing about the code.
+
+This file is the tie. It imports turbodesign and checks that
+`flow_math.compute_streamline_areas` still computes what `buggy_band_area` reproduces.
+
+It is expected to fail when the area formula is fixed, and it should then be updated: at
+that point `buggy_band_area` is a record of the old formula, `compute_streamline_areas`
+should agree with `pappus_band_area` instead, and this file should say so.
+"""
+
+import numpy as np
+import pytest
+
+from tests.test_band_area_oracle import buggy_band_area, pappus_band_area
+from turbodesign.bladerow import BladeRow
+from turbodesign.flow_math import compute_streamline_areas
+
+# A cone: one band, hub 0.25 -> shroud 0.35 in radius over 0.10 in x. dx is well above the
+# 1e-5 guard at flow_math.py:32, so this takes the radial branch.
+X1, R1, X2, R2 = 0.0, 0.25, 0.10, 0.35
+
+
+def _cone_row() -> BladeRow:
+    row = BladeRow()
+    row.percent_hub_shroud = np.array([0.0, 1.0])
+    row.x = np.array([X1, X2])
+    row.r = np.array([R1, R2])
+    return row
+
+
+def test_the_library_still_computes_what_the_oracle_reproduces():
+    """If this fails, either the library's area formula changed or the reproduction drifted.
+    Either way test_band_area_oracle.py needs updating -- that is what this test is for.
+    """
+    total_area, streamline_area = compute_streamline_areas(_cone_row())
+    expected = buggy_band_area(X1, R1, X2, R2)
+    assert streamline_area[1] == pytest.approx(expected, rel=1e-12)
+    assert total_area == pytest.approx(expected, rel=1e-12)
+
+
+def test_the_library_area_is_currently_below_the_geometric_area_on_a_cone():
+    """The consequence, stated against the library rather than against the reproduction: on
+    this cone the area the library computes is 15.0% below the surface of revolution the
+    geometry defines. Fixing flow_math.py:40 will make these two agree and this test fail.
+    """
+    total_area, _ = compute_streamline_areas(_cone_row())
+    exact = pappus_band_area(X1, R1, X2, R2)
+    err = (total_area - exact) / exact
+    assert err == pytest.approx(-0.150, abs=0.001), (
+        f"library area {total_area:.6f} m2 vs geometric area {exact:.6f} m2 ({err:.2%})"
+    )

--- a/tests/test_enthalpy_loss.py
+++ b/tests/test_enthalpy_loss.py
@@ -1,0 +1,173 @@
+# tests/test_enthalpy_loss.py
+"""compressor_math.py handles LossType.Pressure / Polytropic / Entropy but had
+no branch at all for LossType.Enthalpy -- every model in
+turbodesign/loss/compressor/otac.py that declares LossType.Enthalpy fell
+through to the bare `else: row.Yp[:] = 0`, and the model itself was never even
+called. Sixteen models were dead code.
+
+A later change attempted to fix this by root-finding a Yp that reproduces the
+efficiency an internal loss implies. That attempt was itself wrong: it
+compared the row's IDEAL exit state (row.T0_is, which derives from row.P0_is)
+against its ACTUAL exit state as if that were a total-to-total efficiency.
+The two are equal only at Yp = 0 (which is why a handful of smoke tests
+passed), and diverge sharply away from it -- delivering several times the
+loss the correlation actually asked for, with no way for either guard in that
+loop to detect it (both read the same wrong quantity). This file's previous
+centrepiece asserted `_eta_tt(...) == approx(0.95)`, which is tautological:
+it checks that the root-find converged using the very formula the root-find
+minimizes, so it cannot fail even when the formula itself is wrong.
+
+The fix here is not a better conversion -- it is to stop converting. Every
+LossType.Enthalpy model now raises NotImplementedError instead of silently
+producing Yp = 0 (the original bug) or a silently-wrong Yp (the regression
+this file now guards against). The five models that carry parasitic work
+(disc friction, recirculation, leakage, or an aggregate of these) raise with
+wording that says so explicitly, because a parasitic loss has no Yp
+representation at all -- it belongs in the denominator of efficiency, not in
+a pressure-loss coefficient. The other eleven raise because the internal ->
+Yp conversion is simply not implemented.
+
+Rows are built directly, following the pattern in test_radial_velocity.py and
+test_bracket_convergence.py.
+"""
+
+import numpy as np
+import pytest
+
+from turbodesign.bladerow import BladeRow
+from turbodesign.enums import RowType
+from turbodesign.compressor_math import rotor_calc
+from turbodesign.loss.compressor import otac
+
+
+def _make_upstream() -> BladeRow:
+    """A converged upstream row feeding the rotor (meanline, one streamline).
+
+    Same radius as the rotor exit (see _make_rotor): U1 == U2, the axial-safe
+    case this library's core assumes, so rotor_calc's own Yp = 0 baseline is
+    genuinely isentropic here (row.entropy_rise == 0) and eta_tt derived from
+    row.T0_is/row.P0_is is meaningful. row.P0 is derived from T, P, T0 via the
+    isentropic stagnation relation rather than picked independently -- an
+    upstream state where P0 is inconsistent with T/P/V corrupts every
+    downstream entropy/efficiency check without ever raising.
+    """
+    row = BladeRow(
+        row_type=RowType.Stator,
+        r=np.array([0.3048]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+    )
+    row.rpm = 9549.297  # omega = rpm*pi/30 = 1000 rad/s
+    row.Vx = np.array([200.0])
+    row.Vt = np.array([150.0])
+    row.Vr = np.array([0.0])
+    row.Vm = np.array([200.0])
+    row.T = np.array([288.0])
+    row.P = np.array([90000.0])
+    V = np.sqrt(row.Vx**2 + row.Vt**2 + row.Vr**2)
+    row.T0 = row.T + V**2 / (2 * row.Cp)
+    row.P0 = row.P * (row.T0 / row.T) ** (row.gamma / (row.gamma - 1))
+    row.total_massflow = 8.0
+    row.alpha1 = np.array([np.radians(30.0)])
+    row.beta1 = np.array([np.radians(-20.0)])
+    row.mu = 1.8e-5
+    row.rho = np.array([1.1])
+    return row
+
+
+def _make_rotor(loss_function, phi_deg: float = 0.0) -> BladeRow:
+    """A rotor row carrying the loss model under test."""
+    row = BladeRow(
+        row_type=RowType.Rotor,
+        r=np.array([0.3048]),
+        phi=np.array([np.radians(phi_deg)]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+        omega=1000.0,
+        total_area=0.05,
+        P0_ratio=1.15,
+        loss_function=loss_function,
+    )
+    row.metal_exit_angle = [-30.0]
+    row.mu = 1.8e-5
+    row.tip_clearance = 0.02
+    # A finite chord (chord defaults to axial_chord/cos(stagger); axial_chord
+    # defaults to -1 and stagger to an array, which several otac correlations
+    # cannot turn into a plain float): give both an explicit, physically
+    # ordinary value.
+    row.axial_chord = 0.05
+    row.stagger = 0.0
+    return row
+
+
+# --- all sixteen LossType.Enthalpy models: every one must raise ------------
+#
+# Named explicitly, by class, with the parasitic/internal split hand-labelled
+# here rather than read off the model's own is_parasitic flag or discovered
+# by scanning the module -- otherwise this test would still pass even if
+# otac.py's flags were wrong, which is exactly the failure mode being guarded
+# against (see test_impeller_various_is_parasitic below for the concrete case
+# that was wrong until this change).
+#
+# The raise fires in compressor_math's up-front loss-type dispatch, before
+# the loss model is ever called, so none of these need the specific geometry
+# some of their correlations would otherwise require (e.g. a genuine
+# hub-to-shroud radius change for ImpellerClearanceJansen) -- solving never
+# gets that far.
+
+_ALL_ENTHALPY_MODELS = [
+    ("diffuser_vaneless_stanitz", otac.DiffuserVanelessStanitz, False),
+    ("impeller_blade_loading_aungier", otac.ImpellerBladeLoadingAungier, False),
+    ("impeller_blade_loading_coppage", otac.ImpellerBladeLoadingCoppage, False),
+    ("impeller_clearance_jansen", otac.ImpellerClearanceJansen, False),
+    ("impeller_disc_friction_daily", otac.ImpellerDiscFrictionDaily, True),
+    ("impeller_incidence_aungier", otac.ImpellerIncidenceAungier, False),
+    ("impeller_incidence_conrad", otac.ImpellerIncidenceConrad, False),
+    ("impeller_leakage_aungier", otac.ImpellerLeakageAungier, True),
+    ("impeller_mixing_aungier", otac.ImpellerMixingAungier, False),
+    ("impeller_mixing_johnston", otac.ImpellerMixingJohnston, False),
+    ("impeller_prescribed", otac.ImpellerPrescribed, False),
+    ("impeller_recirculation_aungier", otac.ImpellerRecirculationAungier, True),
+    ("impeller_recirculation_oh", otac.ImpellerRecirculationOh, True),
+    ("impeller_skin_friction_coppage", otac.ImpellerSkinFrictionCoppage, False),
+    ("impeller_skin_friction_jansen", otac.ImpellerSkinFrictionJansen, False),
+    ("impeller_various", otac.ImpellerVarious, True),
+]
+
+
+def test_enumerates_exactly_sixteen_models_five_parasitic():
+    assert len(_ALL_ENTHALPY_MODELS) == 16
+    assert sum(1 for _, _, is_parasitic in _ALL_ENTHALPY_MODELS if is_parasitic) == 5
+    assert (
+        sum(1 for _, _, is_parasitic in _ALL_ENTHALPY_MODELS if not is_parasitic) == 11
+    )
+
+
+@pytest.mark.parametrize(
+    "name,model_cls,is_parasitic",
+    _ALL_ENTHALPY_MODELS,
+    ids=[m[0] for m in _ALL_ENTHALPY_MODELS],
+)
+def test_enthalpy_model_raises_not_implemented(name, model_cls, is_parasitic):
+    upstream = _make_upstream()
+    row = _make_rotor(model_cls())
+
+    expected_phrase = "parasitic" if is_parasitic else "not implemented here"
+    with pytest.raises(NotImplementedError, match=expected_phrase):
+        rotor_calc(row, upstream, calculate_vm=True)
+
+
+# --- regression: ImpellerVarious must be flagged parasitic ------------------
+#
+# ImpellerVarious.__call__ sums disc_friction + leakage + recirculation (all
+# three parasitic) together with several internal terms into a single
+# Enthalpy number. Before this change it was is_parasitic=False, so the (now
+# removed) Yp root-find would have silently converted parasitic work into a
+# pressure-loss coefficient. Pinning the flag directly, independent of the
+# raise-wording test above, so a future edit cannot flip it back unnoticed.
+
+
+def test_impeller_various_is_parasitic():
+    assert otac.ImpellerVarious().is_parasitic is True

--- a/tests/test_ideal_relative_pressure.py
+++ b/tests/test_ideal_relative_pressure.py
@@ -1,0 +1,78 @@
+# tests/test_ideal_relative_pressure.py
+"""The lossless exit relative total pressure must be isentropic, not a copy of the inlet.
+
+compressor_math.py sets P0R_local = upstream.P0R - Yp * (upstream.P0R - upstream.P) in
+rotor_calc. At Yp = 0 that reads P0R2_ideal = P0R1, which holds only when U2 == U1. The
+same function computes T0R2 from rothalpy conservation using the local U = omega*r --
+and its own comment says so. Whenever the rotor's radius differs from its upstream radius,
+U2 != U1, so T0R2 != T0R1, and a P0R2_ideal that does not move with T0R2 cannot be
+isentropic.
+
+The identity checked here is the same one derived independently, without importing this
+library, in tests/test_relative_frame_oracle.py:
+
+    P0R2 / P0R1 == (T0R2 / T0R1) ** (gamma / (gamma - 1))
+
+Row setup follows tests/test_radial_velocity.py; the only difference is that the rotor's
+radius is built away from the upstream radius so U2 != U1 actually occurs.
+"""
+
+import numpy as np
+import pytest
+
+from turbodesign.bladerow import BladeRow
+from turbodesign.enums import RowType
+from turbodesign.loss.fixedpressureloss import FixedPressureLoss
+from turbodesign.compressor_math import rotor_calc
+
+
+def _make_upstream() -> BladeRow:
+    row = BladeRow(
+        row_type=RowType.Stator,
+        r=np.array([0.28]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+    )
+    row.rpm = 9549.297  # omega = rpm*pi/30 = 1000 rad/s
+    row.Vx = np.array([200.0])
+    row.Vt = np.array([150.0])
+    row.Vr = np.array([0.0])
+    row.Vm = np.array([200.0])
+    row.T = np.array([288.0])
+    row.P = np.array([90000.0])
+    row.P0 = np.array([101325.0])
+    row.total_massflow = 8.0
+    return row
+
+
+def _make_rotor() -> BladeRow:
+    """A rotor whose radius genuinely differs from its upstream row's, so U2 != U1."""
+    row = BladeRow(
+        row_type=RowType.Rotor,
+        r=np.array([0.32]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+        omega=1000.0,
+        total_area=0.05,
+        P0_ratio=1.15,
+        loss_function=FixedPressureLoss(0.0),
+    )
+    row.metal_exit_angle = [-30.0]
+    return row
+
+
+def test_ideal_exit_relative_pressure_is_isentropic_not_a_copy_of_inlet():
+    upstream = _make_upstream()
+    row = _make_rotor()
+
+    rotor_calc(row, upstream, calculate_vm=True)
+
+    assert row.r[0] != upstream.r[0]  # sanity: this row actually exercises U2 != U1
+    assert row.T0R != pytest.approx(
+        upstream.T0R, rel=1e-9
+    )  # sanity: rothalpy moved T0R
+
+    expected_ratio = (row.T0R / upstream.T0R) ** (row.gamma / (row.gamma - 1.0))
+    assert row.P0R / upstream.P0R == pytest.approx(expected_ratio, rel=1e-9)

--- a/tests/test_no_gui_imports.py
+++ b/tests/test_no_gui_imports.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_importing_spool_modules_does_not_pull_in_gui_toolkits():
+    """The solver must be importable on a headless machine with no Tk.
+
+    turtle (and the tkinter it wraps) has no place in the import graph of a
+    numerical library; pulling it in turns a missing display into an
+    import-time crash.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import turbodesign.compressor_spool, turbodesign.turbine_spool; "
+            "assert 'turtle' not in sys.modules, 'turtle was imported'; "
+            "assert 'tkinter' not in sys.modules, 'tkinter was imported'",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"import check failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/test_radial_velocity.py
+++ b/tests/test_radial_velocity.py
@@ -1,0 +1,94 @@
+# tests/test_radial_velocity.py
+"""Drives rotor_calc directly with a non-zero meridional flow angle (phi).
+
+Every shipped example (both Mattingly cases) constructs its Passage with
+zero_phi=True, so phi is identically 0 there and sin(phi) == 0 makes both the
+correct and the buggy form of Vr agree. That means the golden-file suite can
+never catch a Vr regression at compressor_math.py:261. This test builds a
+rotor BladeRow with phi != 0 directly and calls rotor_calc on it so the buggy
+line actually executes.
+
+Closure identity (see tests/test_velocity_triangle_oracle.py and
+radial-equilibrium-derivation.md, Section 11 / Section 13's code-mapping
+table): Vr = Vm*sin(phi), Vx = Vm*cos(phi), so Vm**2 == Vx**2 + Vr**2.
+"""
+
+import numpy as np
+import pytest
+
+from turbodesign.bladerow import BladeRow
+from turbodesign.enums import RowType
+from turbodesign.loss.fixedpressureloss import FixedPressureLoss
+from turbodesign.compressor_math import rotor_calc
+
+
+def _make_upstream() -> BladeRow:
+    """A converged upstream row feeding the rotor (meanline, one streamline)."""
+    row = BladeRow(
+        row_type=RowType.Stator,
+        r=np.array([0.3048]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+    )
+    row.rpm = 9549.297  # omega = rpm*pi/30 = 1000 rad/s
+    row.Vx = np.array([200.0])
+    row.Vt = np.array([150.0])
+    row.Vr = np.array([0.0])
+    row.Vm = np.array([200.0])
+    row.T = np.array([288.0])
+    row.P = np.array([90000.0])
+    row.P0 = np.array([101325.0])
+    row.total_massflow = 8.0
+    return row
+
+
+def _make_rotor(phi_deg: float) -> BladeRow:
+    """A rotor row with a genuinely non-zero meridional flow angle."""
+    row = BladeRow(
+        row_type=RowType.Rotor,
+        r=np.array([0.3048]),
+        phi=np.array([np.radians(phi_deg)]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+        omega=1000.0,
+        total_area=0.05,
+        P0_ratio=1.15,
+        loss_function=FixedPressureLoss(0.0),
+    )
+    row.metal_exit_angle = [-30.0]
+    return row
+
+
+def test_rotor_radial_velocity_uses_meridional_not_relative_velocity():
+    """compressor_math.py:261 must build Vr from Vm, not W.
+
+    Three other sites in the same file already do this correctly (:85, :177,
+    :365), and radial-equilibrium-derivation.md documents it explicitly:
+    Vr = Vm*sin(phi) (Section 11; Section 13's code-mapping table maps it to
+    `Vr = Vm*np.sin(phi)` literally). Line 261 is the one site that instead
+    writes `Vr = W*np.sin(phi)`, a frame error: W is the relative velocity,
+    a different vector with a different magnitude than Vm.
+    """
+    upstream = _make_upstream()
+    row = _make_rotor(phi_deg=20.0)
+
+    rotor_calc(row, upstream, calculate_vm=True)
+
+    assert row.phi[0] != 0.0  # sanity: the bug is invisible at phi == 0
+    assert row.Vr == pytest.approx(row.Vm * np.sin(row.phi), rel=1e-9)
+
+
+def test_rotor_velocity_triangle_closes_off_axis():
+    """Vm**2 == Vx**2 + Vr**2 -- an identity, not a correlation.
+
+    See tests/test_velocity_triangle_oracle.py for the independent oracle
+    that derives this same closure without importing turbodesign.
+    """
+    upstream = _make_upstream()
+    row = _make_rotor(phi_deg=20.0)
+
+    rotor_calc(row, upstream, calculate_vm=True)
+
+    assert row.Vm**2 == pytest.approx(row.Vx**2 + row.Vr**2, rel=1e-9)

--- a/tests/test_recirculation_oh.py
+++ b/tests/test_recirculation_oh.py
@@ -1,0 +1,129 @@
+# tests/test_recirculation_oh.py
+"""turbodesign/loss/compressor/otac.py's ImpellerRecirculationOh.__call__
+wraps row.alpha2 in np.radians(...) before using it in the correlation.
+row.alpha2 is already in radians -- see turbodesign/bladerow.py's "Flow
+Angles (radians)" docstring (around line 99), and the metal_exit_angle
+setter (bladerow.py ~line 567) that converts the input degrees to radians
+once via np.radians and assigns the result straight to alpha2/beta2. The
+only place alpha2 is converted back to degrees is the display boundary
+(bladerow.py ~line 705, np.degrees(self.alpha2)).
+
+So the model applies a second, spurious degrees->radians conversion on top
+of an already-radians value. Since the argument is cubed inside
+sinh(3.5 * x**3), the suppression compounds to roughly (pi/180)**3, and the
+correlation is numerically flat regardless of flow angle for every
+physically ordinary value of alpha2.
+
+ImpellerRecirculationOh is parasitic (is_parasitic=True); compressor_math
+raises NotImplementedError if it is wired up as a row's loss_function (see
+test_enthalpy_loss.py). So this file drives the model directly rather than
+through rotor_calc/stator_calc, and supplies the row state (U, T0) that the
+solver would ordinarily have already set up before calling a loss_function.
+
+Rows are built with the same fixtures used in test_enthalpy_loss.py.
+"""
+
+import numpy as np
+import pytest
+
+from turbodesign.loss.compressor import otac
+
+from .test_enthalpy_loss import _make_rotor, _make_upstream
+
+
+def _build(alpha2_deg: float):
+    """upstream/row pair, driven directly (see module docstring)."""
+    model = otac.ImpellerRecirculationOh()
+    upstream = _make_upstream()
+    row = _make_rotor(model)
+    row.U = row.omega * row.r
+    row.alpha2 = np.array([np.radians(alpha2_deg)])
+    # T0 rise large enough that the model's internal cap never binds across
+    # the angle range exercised below (see test_loss_grows_with_alpha2).
+    row.T0 = upstream.T0 + 200.0
+    return row, upstream, model
+
+
+def _expected_dh(row, upstream, model, alpha2_rad: float) -> float:
+    """Independent re-derivation of the Oh recirculation correlation -- not
+    a call into the model under test -- with alpha2 supplied explicitly in
+    radians by the caller.
+    """
+    r_tip_in = (
+        model.radius_tip_inlet
+        if model.radius_tip_inlet is not None
+        else float(np.max(upstream.r))
+    )
+    r_exit = (
+        model.radius_exit if model.radius_exit is not None else float(np.max(row.r))
+    )
+    W_row = float(np.linalg.norm(np.asarray(getattr(row, "W", row.V))))
+    Kbl = 0.75 if model.splitter_le == 0 else 0.6
+    Df = (
+        1
+        - W_row / max(model.surge_vrel, 1e-6)
+        + Kbl
+        * model.loading_coefficient
+        / max(
+            (model.surge_vrel / max(W_row, 1e-6))
+            * (
+                (model.number_of_blades / np.pi) * (1 - r_tip_in / max(r_exit, 1e-6))
+                + 2 * r_tip_in / max(r_exit, 1e-6)
+            ),
+            1e-6,
+        )
+    )
+
+    U = float(np.mean(row.U))
+    dh = 8e-5 * np.sinh(3.5 * alpha2_rad**3) * Df**2 * U**2
+
+    cp = float(np.mean([row.Cp, upstream.Cp]))
+    cap = 0.5 * cp * (float(np.mean(row.T0)) - float(np.mean(upstream.T0)))
+    return float(np.clip(dh * model.loss_modifier, 0.0, cap))
+
+
+def test_matches_independent_correlation_with_alpha2_in_radians():
+    """The model must reproduce the correlation evaluated with alpha2 taken
+    as-is in radians -- no second conversion.
+    """
+    alpha2_deg = 60.0
+    row, upstream, model = _build(alpha2_deg)
+
+    actual = float(np.mean(model(row, upstream)))
+    expected = _expected_dh(row, upstream, model, np.radians(alpha2_deg))
+
+    assert actual == pytest.approx(expected, rel=1e-9)
+
+
+def test_generated_suppression_factor_matches_pi_over_180_cubed():
+    """Characterizes the magnitude of the defect via the correlation's own
+    math, independent of the model under test: at a small angle,
+    sinh(3.5*x**3) ~ 3.5*x**3 on both branches, so wrapping an
+    already-radians x in a second np.radians(...) suppresses the result by
+    ~(pi/180)**3. The ratio is generated here, not typed in from a brief.
+    """
+    alpha2_rad = np.radians(5.0)
+
+    row, upstream, model = _build(5.0)
+    correct = _expected_dh(row, upstream, model, alpha2_rad)
+    doubly_converted = _expected_dh(row, upstream, model, np.radians(alpha2_rad))
+
+    suppression_ratio = doubly_converted / correct
+    assert suppression_ratio == pytest.approx((np.pi / 180) ** 3, rel=1e-3)
+
+
+def test_loss_grows_with_alpha2():
+    """The correlation must respond to the exit flow angle: sinh(3.5*x**3)
+    is steeply increasing in x for the range exercised here. Pre-fix, the
+    doubly-suppressed argument keeps sinh(...) pinned in its near-zero
+    linear regime across this whole range, so the growth from a shallow to
+    a steep exit angle is nowhere near this large.
+    """
+    angles_deg = [20.0, 40.0, 60.0, 80.0]
+    dh_values = []
+    for a in angles_deg:
+        row, upstream, model = _build(a)
+        dh_values.append(float(np.mean(model(row, upstream))))
+
+    assert all(b > a for a, b in zip(dh_values, dh_values[1:]))
+    assert dh_values[-1] / dh_values[0] > 1000

--- a/tests/test_relative_frame_oracle.py
+++ b/tests/test_relative_frame_oracle.py
@@ -1,0 +1,152 @@
+# tests/test_relative_frame_oracle.py
+"""The ideal relative-frame total pressure, checked against thermodynamics.
+
+This module does not import turbodesign for its arithmetic: it is an independent oracle,
+and a code that agrees with itself is not validated. The one exception is the last test,
+which reads a converged solve through the `example_spool` fixture in order to compare the
+library's own numbers against the closure derived here.
+
+compressor_math.py:246 sets the ideal exit relative total pressure to the inlet value,
+P0R2_ideal = P0R1. That holds only when U2 == U1. Three lines below, :249 computes T0R2
+from rothalpy using the local U = omega*r. The two lines cannot both be right. The ideal
+exit relative total pressure is isentropic in the rotating frame between T0R1 and T0R2:
+
+    P0R2_ideal = P0R1 * (T0R2/T0R1)**(gamma/(gamma-1))
+
+A note on the closure. The exponent form above assumes constant cp. This library's gas
+model is Cantera, i.e. cp varies with temperature, and the rigorous isentropic closure for
+a variable-cp ideal gas is
+
+    ln(P0R2/P0R1)|_s = (1/R) * integral_{T0R1}^{T0R2} cp(T)/T dT
+
+which collapses to the constant-gamma form only when cp is constant. The two are not
+interchangeable by assumption, so the difference is measured here rather than asserted
+away (test_the_two_closures_agree_to_within_a_tenth_of_the_delta). Over the temperature
+span the examples actually cover it is 1.6% of the pressure-ratio delta, which is small
+enough to quote the constant-gamma number -- provided that choice is stated. Re-run this
+file if the gas model or the temperature range changes.
+"""
+
+import numpy as np
+import pytest
+from scipy.integrate import quad
+
+R_AIR = 287.05
+CP_AIR = 1004.0  # J/kg-K, near 290 K
+
+
+def ideal_P0R_ratio_constant_gamma(T0R1: float, T0R2: float, gamma: float) -> float:
+    return (T0R2 / T0R1) ** (gamma / (gamma - 1.0))
+
+
+def ideal_P0R_ratio_variable_cp(
+    T0R1: float, T0R2: float, cp_of_T, R: float = R_AIR
+) -> float:
+    integral, _ = quad(lambda T: cp_of_T(T) / T, T0R1, T0R2, epsabs=1e-12, epsrel=1e-12)
+    return float(np.exp(integral / R))
+
+
+def T0R2_from_rothalpy(T0R1: float, U1: float, U2: float, cp: float = CP_AIR) -> float:
+    """Rothalpy I = h + W**2/2 - U**2/2 is conserved across a rotor. With h0_rel = cp*T0R,
+
+        cp*T0R1 - U1**2/2 = cp*T0R2 - U2**2/2   ->   T0R2 = T0R1 + (U2**2 - U1**2)/(2*cp)
+
+    The -U**2/2 term is what carries the radius change; it is identically zero only when
+    U2 == U1.
+    """
+    return T0R1 + (U2**2 - U1**2) / (2.0 * cp)
+
+
+def test_variable_cp_reduces_to_constant_gamma_when_cp_is_constant():
+    """The two closures must agree exactly in the limit. If they do not, the oracle is wrong."""
+    gamma = 1.4
+    cp = gamma * R_AIR / (gamma - 1.0)
+    a = ideal_P0R_ratio_constant_gamma(288.0, 320.0, gamma)
+    b = ideal_P0R_ratio_variable_cp(288.0, 320.0, lambda T: cp)
+    assert b == pytest.approx(a, rel=1e-12)
+
+
+def test_the_ideal_ratio_is_one_when_the_blade_speed_is_unchanged():
+    """One direction of the equivalence, and the only case in which :246 is right.
+
+    U2 == U1 makes the rothalpy term vanish, so T0R2 == T0R1 and the ideal ratio is 1
+    under both closures -- which is what compressor_math.py:246 hard-codes.
+    """
+    U = 291.0
+    T0R2 = T0R2_from_rothalpy(288.0, U, U)
+    assert T0R2 == 288.0
+    assert ideal_P0R_ratio_constant_gamma(288.0, T0R2, 1.4) == 1.0
+    assert ideal_P0R_ratio_variable_cp(
+        288.0, T0R2, lambda T: 1004.0 + 0.04 * T
+    ) == pytest.approx(1.0, rel=1e-15)
+
+
+def test_the_ideal_ratio_departs_from_one_when_the_blade_speed_changes():
+    """The other direction, and the defect. A rotor whose radius contracts by 10% along a
+    streamline drops U from 290 to 261 m/s. Rothalpy then puts T0R2 8 K below T0R1, and the
+    ideal relative total pressure ratio is 0.907 -- not the 1.0 that :246 assigns it.
+    """
+    T0R1, U1, U2 = 288.0, 290.0, 261.0
+    T0R2 = T0R2_from_rothalpy(T0R1, U1, U2)
+    assert T0R2 == pytest.approx(280.04, abs=0.01)
+
+    ratio = ideal_P0R_ratio_constant_gamma(T0R1, T0R2, 1.4)
+    assert ratio == pytest.approx(0.9066, abs=1e-4)
+    assert abs(ratio - 1.0) > 0.05, (
+        f"a 10% radius change should move the ideal ratio by several percent, got {ratio}"
+    )
+
+
+def test_the_two_closures_agree_to_within_a_tenth_of_the_delta():
+    """Bound the disagreement between the constant-gamma and variable-cp closures; do not
+    assume it is negligible.
+
+    The range used is the one the library actually spans across the rotor of Mattingly
+    example 9.1 at the hub streamline: T0R goes from 287.147118 K to 288.256793 K, i.e.
+    1.11 K. cp(T) for air is represented by a linear fit whose slope is a bounding
+    sensitivity, not a fitted real-gas value; the NASA-Glenn/McBride polynomial is not
+    reproduced here. Over that span the two closures give 1.013529 and 1.013739. The
+    quantity that matters is not the ratio but the delta from unity -- 0.013529 -- and the
+    closures differ by 1.6% of it. That is small enough to quote the constant-gamma
+    number, so long as the closure used is stated rather than left implicit.
+    """
+    cp0, dcp_dT = (
+        1004.0,
+        0.04,
+    )  # J/kg-K, J/kg-K**2 -- bounding slope, not a fitted value
+    T1, T2 = 287.147118, 288.256793  # example 9.1, hub streamline, across the rotor
+    const = ideal_P0R_ratio_constant_gamma(T1, T2, 1.402560)
+    varcp = ideal_P0R_ratio_variable_cp(T1, T2, lambda T: cp0 + dcp_dT * T)
+    spread = abs(varcp - const) / (const - 1.0)  # relative to the delta, not to 1.0
+    assert spread < 0.10, (
+        f"the two closures disagree by {spread:.1%} of the delta ({const=}, {varcp=}). "
+        f"A published delta must state which closure produced it."
+    )
+
+
+def test_the_meanline_is_not_a_no_op_under_a_variable_cp_gas(example_spool):
+    """At the meanline of example 9.1 the radius is unchanged across the rotor, so the
+    argument above says T0R2/T0R1 should be exactly 1 and :246 should be exactly right
+    there. The library returns 0.99939 instead, because its gas is variable-cp: cp is not
+    the same on the two rows, so cp*T0R1 - U**2/2 = cp*T0R2 - U**2/2 no longer forces
+    T0R1 == T0R2.
+
+    That is 6e-4 in T0R and about 2e-3 in the ideal pressure ratio. It is small, but it is
+    not zero, and a test that pinned the meanline at 1 to within 1e-9 would be pinning the
+    wrong number. The value is read from the solve rather than hardcoded, so it tracks the
+    library.
+    """
+    loc = example_spool("mattingly-axial-compressor/example9.1.py")
+    inlet, rotor = loc["spool"].blade_rows[0], loc["rotor"]
+
+    mean = 1  # hub, mean, shroud
+    assert rotor.r[mean] == pytest.approx(inlet.r[mean], rel=1e-12), (
+        "example 9.1 is supposed to hold the mean radius constant across the rotor"
+    )
+
+    tau = rotor.T0R[mean] / inlet.T0R[mean]
+    delta = ideal_P0R_ratio_constant_gamma(1.0, tau, 1.402560) - 1.0
+    assert abs(delta) > 1e-3, (
+        f"T0R is unchanged across the meanline to within {abs(tau - 1.0):.1e}; if this "
+        f"ever becomes exact, the gas model has changed and this test's premise with it"
+    )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,6 @@
+# tests/test_smoke.py
+"""The library imports."""
+
+
+def test_turbodesign_imports():
+    import turbodesign  # noqa: F401

--- a/tests/test_turbine_characterization.py
+++ b/tests/test_turbine_characterization.py
@@ -1,0 +1,298 @@
+# tests/test_turbine_characterization.py
+"""Pin the current behaviour of the axial and radial turbine examples.
+
+Why this file exists: `flow_math.compute_streamline_areas` computes streamtube areas with
+`2*pi*C*(S/2*dx**2 + r*dx)`, where S is a radius difference in metres. The first term is a
+cubic metre and the second a square metre, so the expression adds a volume to an area (see
+tests/test_band_area_oracle.py). That function is shared -- `turbine_math.py:306` calls it
+directly and `turbine_spool.py` reaches it through `compute_massflow` -- so correcting the
+area formula will change axial turbine results too, and axial turbines are this library's
+primary published use case.
+
+These are characterization goldens: they record what the code does today, not what is
+physically correct. `eee_hpt.py` is expected to move once the shared area fix lands; the
+point of pinning it now is that the change is then visible rather than discovered.
+`radial_turbine-1D.py` is pinned because it should move further: it is a radial machine, so
+it takes the buggy branch on every band. Over its solve, `compute_streamline_areas` is
+called 64 times and the radial branch body executes 256 times (64 calls x 4 bands at 5
+streamlines), at meridional angles up to 89.96 degrees. The axial branch never runs.
+
+Both sets of goldens were produced by running the examples on this tree (see
+`tests/conftest.py::_run`).
+"""
+
+import pytest
+
+RTOL = 1e-9
+
+
+# ---------------------------------------------------------------------------
+# examples/EEE-HPT/eee_hpt.py -- 2-stage axial turbine, SLSQP multi-stage pressure
+# balance (turbodesign/turbine_spool.py:_balance_pressure, fmin_slsqp branch).
+#
+# This example has no main() -- it is a flat top-level script -- so `example_spool`
+# returns its module namespace directly. It defines `stator1`, `rotor1`, `stator2`,
+# `rotor2` (the same BladeRow objects that are inside `spool.rows`, mutated in place
+# by `spool.solve()`) and `spool` itself. Runtime is ~7-8s (SLSQP + 5 streamlines),
+# hence @pytest.mark.slow.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_eee_hpt_is_five_streamlines(example_spool):
+    spool = example_spool("EEE-HPT/eee_hpt.py")["spool"]
+    assert spool.num_streamlines == 5
+
+
+@pytest.mark.slow
+def test_eee_hpt_massflow_attribute_is_the_input_echo(example_spool):
+    """`spool.massflow` is set once at construction (turbine_spool.py:92) and is never
+    written back to during `.solve()` in pressure-balance mode; only
+    `solve_massflow_for_power`, which this example does not use, updates it. So the
+    attribute is not the converged massflow -- it is the 20 kg/s guess the example passed
+    in. The converged value is pinned separately below, from `spool.convergence_history`.
+    """
+    spool = example_spool("EEE-HPT/eee_hpt.py")["spool"]
+    assert spool.massflow == pytest.approx(20.0, rel=RTOL)
+
+
+@pytest.mark.slow
+def test_eee_hpt_stator1_per_streamline(example_spool):
+    row = example_spool("EEE-HPT/eee_hpt.py")["stator1"]
+    assert row.P0 == pytest.approx([1230607.077101921] * 5, rel=RTOL)
+    assert row.T0 == pytest.approx([1587.0] * 5, rel=RTOL)
+    assert row.M == pytest.approx(
+        [
+            0.9008453280523004,
+            0.8753927855297182,
+            0.8517684601550825,
+            0.8297668414327242,
+            0.809148370680553,
+        ],
+        rel=RTOL,
+    )
+    assert row.Yp == pytest.approx([0.057] * 5, rel=RTOL)
+
+
+@pytest.mark.slow
+def test_eee_hpt_rotor1_per_streamline(example_spool):
+    row = example_spool("EEE-HPT/eee_hpt.py")["rotor1"]
+    assert row.P0 == pytest.approx(
+        [
+            578345.3532063541,
+            568953.3631594869,
+            561067.2952288443,
+            554464.6265053176,
+            549027.9543868615,
+        ],
+        rel=RTOL,
+    )
+    assert row.T0 == pytest.approx(
+        [
+            1343.4794419417044,
+            1338.351413116741,
+            1334.0491926457082,
+            1330.470258091159,
+            1327.5634278022285,
+        ],
+        rel=RTOL,
+    )
+    assert row.M == pytest.approx(
+        [
+            0.39115615492041317,
+            0.3761548794976443,
+            0.36377563900765325,
+            0.35378845466081904,
+            0.3458730120679529,
+        ],
+        rel=RTOL,
+    )
+    assert row.Yp == pytest.approx([0.088] * 5, rel=RTOL)
+
+
+@pytest.mark.slow
+def test_eee_hpt_stator2_per_streamline(example_spool):
+    row = example_spool("EEE-HPT/eee_hpt.py")["stator2"]
+    assert row.P0 == pytest.approx(
+        [
+            564286.1117135661,
+            555542.1689799328,
+            548200.2397365044,
+            542053.1551549011,
+            536991.6134126185,
+        ],
+        rel=RTOL,
+    )
+    assert row.M == pytest.approx(
+        [
+            0.8623745634810988,
+            0.8197532030358293,
+            0.7825474243432641,
+            0.7498246933734738,
+            0.7206268276705512,
+        ],
+        rel=RTOL,
+    )
+    assert row.Yp == pytest.approx([0.069] * 5, rel=RTOL)
+
+
+@pytest.mark.slow
+def test_eee_hpt_rotor2_per_streamline(example_spool):
+    row = example_spool("EEE-HPT/eee_hpt.py")["rotor2"]
+    assert row.P0 == pytest.approx(
+        [
+            270414.06537260045,
+            263897.33914370113,
+            259578.78860271804,
+            257046.7352292148,
+            256108.09563705017,
+        ],
+        rel=RTOL,
+    )
+    assert row.T0 == pytest.approx(
+        [
+            1134.8998922573246,
+            1128.4000244077208,
+            1124.1007855487087,
+            1121.6582500344703,
+            1120.9101696617186,
+        ],
+        rel=RTOL,
+    )
+    assert row.M == pytest.approx(
+        [
+            0.4721947561743981,
+            0.4490594317991563,
+            0.43211060563523745,
+            0.420354573458027,
+            0.4127988942866575,
+        ],
+        rel=RTOL,
+    )
+    assert row.Yp == pytest.approx([0.014] * 5, rel=RTOL)
+
+
+@pytest.mark.slow
+def test_eee_hpt_slsqp_tripwire(example_spool):
+    """A coarse tripwire, deliberately looser than the row-level goldens above.
+
+    `fmin_slsqp`'s own `x`/`fun` live inside `TurbineSpool._balance_pressure`
+    (turbodesign/turbine_spool.py) and are never assigned to an attribute the example can
+    see, so they cannot be pinned without reaching into library internals.
+    `spool.convergence_history[-1]` records the same optimizer's final objective value
+    (`massflow_std`, what `fmin_slsqp` was minimizing) and its iteration count, which
+    answers the same question: did the solver converge to roughly the same place. For
+    anything that needs to be exact, prefer the per-row assertions above.
+    """
+    spool = example_spool("EEE-HPT/eee_hpt.py")["spool"]
+    assert len(spool.convergence_history) == 106
+    last = spool.convergence_history[-1]
+    assert last["massflow_std"] == pytest.approx(0.0014191633426164, rel=1e-6)
+    assert last["massflow"] == pytest.approx(29.2606442034497, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# examples/radial-turbine/radial_turbine-1D.py -- single-stage CENTRIFUGAL turbine,
+# single-stage pressure balance (turbodesign/turbine_spool.py:_balance_pressure,
+# minimize_scalar branch -- only one stage, so fmin_slsqp is not used here).
+#
+# Pinned because it is expected to move once the area fix lands: this passage takes the
+# `S/2 * dx**2` branch of `compute_streamline_areas` (flow_math.py:40) on every band --
+# 256 band evaluations over 64 calls -- at meridional angles up to 89.96 degrees, where
+# the term being added is dimensionally a volume rather than an area. On an axial machine
+# that term is small; here it is not. This example also has no main(); `example_spool`
+# returns its module namespace, which defines `stator`, `rotor`, and `spool`.
+# ---------------------------------------------------------------------------
+
+
+def test_radial_turbine_is_five_streamlines(example_spool):
+    spool = example_spool("radial-turbine/radial_turbine-1D.py")["spool"]
+    assert spool.num_streamlines == 5
+
+
+def test_radial_turbine_massflow_attribute_is_the_input_echo(example_spool):
+    """As with EEE-HPT: `spool.massflow` is the unconverged 0.1 kg/s guess passed into the
+    constructor, not the converged value. See
+    `test_eee_hpt_massflow_attribute_is_the_input_echo`.
+    """
+    spool = example_spool("radial-turbine/radial_turbine-1D.py")["spool"]
+    assert spool.massflow == pytest.approx(0.1, rel=RTOL)
+
+
+def test_radial_turbine_stator_per_streamline(example_spool):
+    row = example_spool("radial-turbine/radial_turbine-1D.py")["stator"]
+    assert row.P0 == pytest.approx([536657.313099755] * 5, rel=RTOL)
+    assert row.T0 == pytest.approx([1222.8779357137] * 5, rel=RTOL)
+    assert row.M == pytest.approx([0.42080703647747797] * 5, rel=RTOL)
+    assert row.Yp == pytest.approx([0.0] * 5, abs=1e-12)
+
+
+def test_radial_turbine_rotor_per_streamline(example_spool):
+    """The golden most likely to move once the shared area fix lands.
+
+    `M` here is the absolute Mach number, and it exceeds 1 at the hub streamline
+    (M[0] = 1.2696). That is not a choked passage: choking is set by the meridional Mach
+    number, which is far lower at a near-radial station, and a swirling flow can carry an
+    absolute Mach number above 1 without it. It is also exactly the kind of station where
+    the extra term in `compute_streamline_areas` is large rather than negligible.
+    """
+    row = example_spool("radial-turbine/radial_turbine-1D.py")["rotor"]
+    assert row.P0 == pytest.approx(
+        [
+            443074.15148622065,
+            437651.6584138988,
+            428537.84499390324,
+            418045.0960861983,
+            409980.2644715815,
+        ],
+        rel=RTOL,
+    )
+    assert row.T0 == pytest.approx(
+        [
+            1161.8429099481775,
+            1158.73767317465,
+            1153.2557718494477,
+            1146.9118258635594,
+            1142.398479508869,
+        ],
+        rel=RTOL,
+    )
+    assert row.M == pytest.approx(
+        [
+            1.269577634397641,
+            0.9756593824217092,
+            0.882204528319701,
+            0.837409532372009,
+            0.7773593618539902,
+        ],
+        rel=RTOL,
+    )
+    assert row.Yp == pytest.approx([0.1358751871641363] * 5, rel=RTOL)
+
+
+def test_radial_turbine_convergence_tripwire(example_spool):
+    """Coarse tripwire on the pressure-balance solve (see the EEE-HPT equivalent
+    above for why this is coarse rather than exact: `minimize_scalar`'s own result
+    object is internal to `_balance_pressure` and is not exposed on `spool`).
+    """
+    spool = example_spool("radial-turbine/radial_turbine-1D.py")["spool"]
+    assert len(spool.convergence_history) == 15
+    last = spool.convergence_history[-1]
+    assert last["massflow_std"] == pytest.approx(2.7887726216979658e-05, rel=1e-6)
+    assert last["massflow"] == pytest.approx(0.29864834362636516, rel=1e-6)
+
+
+@pytest.mark.slow
+def test_the_turbine_examples_are_deterministic(example_spool):
+    """If the baseline does not reproduce bit for bit, nothing pinned above means anything.
+    Checked here on the radial turbine, the cheaper of the two examples to run twice.
+    """
+    from tests.conftest import EXAMPLES, _run
+
+    a = _run(EXAMPLES / "radial-turbine" / "radial_turbine-1D.py")[
+        "spool"
+    ].convergence_history[-1]["massflow_std"]
+    b = _run(EXAMPLES / "radial-turbine" / "radial_turbine-1D.py")[
+        "spool"
+    ].convergence_history[-1]["massflow_std"]
+    assert a == b

--- a/tests/test_turbine_characterization.py
+++ b/tests/test_turbine_characterization.py
@@ -192,7 +192,7 @@ def test_eee_hpt_slsqp_tripwire(example_spool):
 
 
 # ---------------------------------------------------------------------------
-# examples/radial-turbine/radial_turbine-1D.py -- single-stage CENTRIFUGAL turbine,
+# examples/radial-turbine/radial_turbine-1D.py -- single-stage radial-inflow turbine,
 # single-stage pressure balance (turbodesign/turbine_spool.py:_balance_pressure,
 # minimize_scalar branch -- only one stage, so fmin_slsqp is not used here).
 #

--- a/tests/test_velocity_triangle_oracle.py
+++ b/tests/test_velocity_triangle_oracle.py
@@ -1,0 +1,82 @@
+# tests/test_velocity_triangle_oracle.py
+"""Triangle closure, checked against the triangle rather than against the library.
+
+This module does not import turbodesign.
+
+compressor_math.py:261 is  Vr = W*sin(phi).  It should be  Vm*sin(phi).  W carries the
+tangential component (W**2 = Vm**2 + Wt**2), so building Vr from W and then forming
+V = sqrt(Vr**2 + Vt**2 + Vx**2) at :267 counts the tangential part twice.
+
+Ten of the eleven sites in the library that build Vr from phi already use Vm (:85, :177,
+:365, inlet.py:175, radeq.py:61, and five in turbine_math.py). One uses W.
+
+The repository's own radial-equilibrium-derivation.md gives the same closure. Section 11
+("Closure -- V_r and V_T in terms of V_M"):
+
+    V_r = V_M sin(phi),    V_T = V_M tan(alpha),    V^2 = V_M^2 (1 + tan^2(alpha))
+
+and the Section 13 code-mapping table repeats it literally:
+
+    | V_r=V_M\\sin\\phi | `Vr = Vm*np.sin(phi)` | closure, Section 11 |
+"""
+
+import numpy as np
+import pytest
+
+
+def triangle_from_Vm(W, beta2, phi, U):
+    """The closure as derived: Vr = Vm*sin(phi)."""
+    Vm = W * np.cos(beta2)
+    Wt = W * np.sin(beta2)
+    Vr = Vm * np.sin(phi)
+    Vx = Vm * np.cos(phi)
+    Vt = Wt + U
+    return Vm, Vr, Vx, Vt, Wt
+
+
+def triangle_from_W(W, beta2, phi, U):
+    """The closure as coded at compressor_math.py:261: Vr = W*sin(phi)."""
+    Vm = W * np.cos(beta2)
+    Wt = W * np.sin(beta2)
+    Vr = W * np.sin(phi)
+    Vx = Vm * np.cos(phi)
+    Vt = Wt + U
+    return Vm, Vr, Vx, Vt, Wt
+
+
+@pytest.mark.parametrize("phi_deg", [0.0, 15.0, 45.0, 90.0])
+def test_meridional_closure_holds_when_Vr_is_built_from_Vm(phi_deg):
+    """Vm**2 == Vx**2 + Vr**2. An identity, not a correlation."""
+    Vm, Vr, Vx, _, _ = triangle_from_Vm(
+        250.0, np.radians(-37.5), np.radians(phi_deg), 300.0
+    )
+    assert Vm**2 == pytest.approx(Vx**2 + Vr**2, rel=1e-12)
+
+
+def test_the_bug_is_invisible_at_phi_zero():
+    """phi == 0 is the definition of an axial station, and the error is (W - Vm)*sin(phi).
+    That is why this has never shown up in an axial case.
+    """
+    a = triangle_from_Vm(250.0, np.radians(-37.5), 0.0, 300.0)
+    b = triangle_from_W(250.0, np.radians(-37.5), 0.0, 300.0)
+    assert a == pytest.approx(b, rel=1e-15)
+
+
+@pytest.mark.parametrize("phi_deg", [15.0, 45.0, 90.0])
+def test_the_bug_breaks_meridional_closure_off_axis(phi_deg):
+    """Off-axis, Vm**2 != Vx**2 + Vr**2: the triangle does not close."""
+    Vm, Vr, Vx, _, _ = triangle_from_W(
+        250.0, np.radians(-37.5), np.radians(phi_deg), 300.0
+    )
+    assert Vm**2 != pytest.approx(Vx**2 + Vr**2, rel=1e-6)
+
+
+def test_the_error_is_W_over_Vm_at_ninety_degrees():
+    """At phi = 90 deg the overstatement is W/Vm = 1/cos(beta2). At 37.5 deg backsweep that
+    is 1.26, so Vr is 26% too large -- and phi = 90 deg is an impeller exit.
+    """
+    beta2 = np.radians(-37.5)
+    _, Vr_ok, _, _, _ = triangle_from_Vm(250.0, beta2, np.pi / 2, 300.0)
+    _, Vr_bug, _, _, _ = triangle_from_W(250.0, beta2, np.pi / 2, 300.0)
+    assert Vr_bug / Vr_ok == pytest.approx(1.0 / np.cos(beta2), rel=1e-12)
+    assert Vr_bug / Vr_ok == pytest.approx(1.26, abs=0.01)

--- a/tests/test_velocity_triangle_oracle.py
+++ b/tests/test_velocity_triangle_oracle.py
@@ -72,8 +72,9 @@ def test_the_bug_breaks_meridional_closure_off_axis(phi_deg):
 
 
 def test_the_error_is_W_over_Vm_at_ninety_degrees():
-    """At phi = 90 deg the overstatement is W/Vm = 1/cos(beta2). At 37.5 deg backsweep that
-    is 1.26, so Vr is 26% too large -- and phi = 90 deg is an impeller exit.
+    """At phi = 90 deg the overstatement is W/Vm = 1/cos(beta2). At 37.5 deg of exit swirl
+    that is 1.26, so Vr comes out 26% too large. The error grows smoothly from zero at
+    phi = 0, so any station with a sloped endwall carries some of it.
     """
     beta2 = np.radians(-37.5)
     _, Vr_ok, _, _, _ = triangle_from_Vm(250.0, beta2, np.pi / 2, 300.0)

--- a/tests/test_yp_dtype.py
+++ b/tests/test_yp_dtype.py
@@ -1,0 +1,115 @@
+# tests/test_yp_dtype.py
+"""BladeRow.Yp defaults to np.array([0]) -- an int64 array, since the literal
+has no decimal point. compressor_math.py writes every trial Yp *in place*
+(`row.Yp[:] = y`, in both the Polytropic and Entropy root-finds in
+stator_calc/rotor_calc), and an in-place write preserves the array's existing
+dtype: a fractional trial value assigned into an int64 array is silently
+floor/truncated to 0.
+
+    >>> row = BladeRow(...)
+    >>> row.Yp.dtype
+    dtype('int64')
+    >>> row.Yp[:] = 0.35
+    >>> row.Yp
+    array([0])
+
+The consequence: every `minimize_scalar` search over Yp in the Polytropic and
+Entropy branches is minimizing a CONSTANT objective (Yp is always 0 inside the
+solve, no matter what trial value the optimizer proposes), so the solved
+state is silently lossless regardless of the requested target. This is
+independent of the LossType.Enthalpy work in tests/test_enthalpy_loss.py --
+which happens to depend on the fix (its own root-find writes `row.Yp[:] = y`
+too) -- but the defect itself sits one level below that, in the field
+default, and would have broken Polytropic/Entropy on its own.
+
+turbine_spool.py's own Enthalpy branch is unaffected: it *rebinds* the
+attribute (`row.Yp = Yp`) rather than writing into the existing array, so it
+never inherits the stale int64 dtype.
+"""
+
+import numpy as np
+import pytest
+
+from turbodesign.bladerow import BladeRow
+from turbodesign.enums import RowType
+from turbodesign.loss.fixedpolytropic import FixedPolytropicEfficiency
+from turbodesign.compressor_math import rotor_calc
+
+
+def test_yp_defaults_to_a_floating_dtype():
+    row = BladeRow(row_type=RowType.Rotor, r=np.array([0.3048]))
+    assert np.issubdtype(row.Yp.dtype, np.floating)
+
+
+def test_inplace_yp_write_does_not_truncate_a_fractional_value():
+    """This is exactly the write compressor_math.py's root-finds perform
+    (`row.Yp[:] = y`) on every trial value the optimizer proposes."""
+    row = BladeRow(row_type=RowType.Rotor, r=np.array([0.3048]))
+    row.Yp[:] = 0.35
+    assert row.Yp == pytest.approx(0.35)
+
+
+def _make_upstream() -> BladeRow:
+    """A thermodynamically self-consistent upstream row (meanline, one
+    streamline): P0 is derived from T, P, T0 via the isentropic stagnation
+    relation rather than picked independently, so eta_poly computed from the
+    solved pi/tau ratios is meaningful."""
+    row = BladeRow(
+        row_type=RowType.Stator,
+        r=np.array([0.3048]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+    )
+    row.rpm = 9549.297  # omega = rpm*pi/30 = 1000 rad/s
+    row.Vx = np.array([200.0])
+    row.Vt = np.array([150.0])
+    row.Vr = np.array([0.0])
+    row.Vm = np.array([200.0])
+    row.T = np.array([288.0])
+    row.P = np.array([90000.0])
+    V = np.sqrt(row.Vx**2 + row.Vt**2 + row.Vr**2)
+    row.T0 = row.T + V**2 / (2 * row.Cp)
+    row.P0 = row.P * (row.T0 / row.T) ** (row.gamma / (row.gamma - 1))
+    row.total_massflow = 8.0
+    return row
+
+
+def test_polytropic_rotor_solves_a_genuinely_nonzero_yp():
+    """End-to-end proof that the Polytropic root-find is not optimizing a
+    constant objective.
+
+    row.eta_poly is set directly (rather than relying on
+    FixedPolytropicEfficiency.__call__'s return value) only to route around
+    an unrelated pre-existing issue in compressor_math.py's eager top-level
+    `float(loss_fn(row, upstream))` call, which cannot convert a
+    multi-element array to a scalar; row.eta_poly being already truthy makes
+    that branch read `float(np.mean(row.eta_poly))` instead. This does not
+    touch the Yp root-find itself, which is what is under test here.
+
+    A polytropic efficiency of 0.9 is well below what this rotor achieves
+    loss-free, so it can only be reached with Yp > 0. Pre-fix (Yp truncating
+    to 0 on every trial), the search below raises RuntimeError: the row's
+    eta_poly is constant regardless of the proposed Yp, so the optimizer
+    cannot approach 0.9 and parks on the bracket's upper edge instead.
+    """
+    upstream = _make_upstream()
+    row = BladeRow(
+        row_type=RowType.Rotor,
+        r=np.array([0.3048]),
+        phi=np.array([0.0]),
+        R=287.15,
+        gamma=1.4,
+        Cp=1004.5,
+        omega=1000.0,
+        total_area=0.05,
+        P0_ratio=1.15,
+        loss_function=FixedPolytropicEfficiency(eta_poly=0.9),
+    )
+    row.metal_exit_angle = [-30.0]
+    row.eta_poly = np.array([0.9])
+
+    rotor_calc(row, upstream, calculate_vm=True)  # must not raise
+
+    assert np.all(row.Yp > 0)
+    assert float(row.eta_poly) == pytest.approx(0.9, abs=1e-3)

--- a/turbodesign/bladerow.py
+++ b/turbodesign/bladerow.py
@@ -280,7 +280,7 @@ class BladeRow:
     incli_curve_radii: npt.NDArray = field(default_factory=lambda: np.array([0]))       # radius at which curvature was evaluated
     mprime: npt.NDArray = field(default_factory=lambda: np.array([0]))                   # Mprime distance
     
-    Yp: npt.NDArray = field(default_factory=lambda: np.array([0]))                       # Pressure loss
+    Yp: npt.NDArray = field(default_factory=lambda: np.array([0.0]))                     # Pressure loss
     blockage: float = 0 
     flow_coefficient: float = 0     # Vm/U or similar nondimensional flow coefficient
     power: float = 0                 # Watts 

--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
-from scipy.optimize import minimize_scalar, minimize
+from scipy.optimize import minimize_scalar
 
 from pyturbo.helper import convert_to_ndarray
 

--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -93,6 +93,24 @@ def stator_calc(row: BladeRow, upstream: BladeRow, calculate_vm: bool = True) ->
                 target_entropy = float(np.mean(row.entropy_rise))
             elif callable(loss_fn):
                 target_entropy = float(loss_fn(row, upstream))  # type: ignore[arg-type]
+        elif loss_type == LossType.Enthalpy:
+            raise NotImplementedError(
+                f"{type(loss_fn).__name__} declares LossType.Enthalpy. The "
+                f"compressor path does not implement it: Yp would silently "
+                f"remain 0 and the row would come out loss-free. "
+                + (
+                    "This model carries parasitic work (disc friction, "
+                    "recirculation, leakage). A parasitic loss raises T0 and "
+                    "destroys no total pressure, so it cannot be expressed as "
+                    "a pressure-loss coefficient at all: it belongs in the "
+                    "denominator of efficiency, and this solver has no "
+                    "parasitic-work term."
+                    if getattr(loss_fn, "is_parasitic", False)
+                    else
+                    "An internal loss can in principle be converted to a Yp, "
+                    "but that conversion is not implemented here."
+                )
+            )
 
     def calculate_vm_func(M_guess: float, apply: bool = False) -> float:
         """Solve stator for a guessed Mach; returns massflow residual."""
@@ -250,6 +268,24 @@ def rotor_calc(
                 target_entropy = float(np.mean(row.entropy_rise))
             elif callable(loss_fn):
                 target_entropy = float(loss_fn(row, upstream))  # type: ignore[arg-type]
+        elif loss_type == LossType.Enthalpy:
+            raise NotImplementedError(
+                f"{type(loss_fn).__name__} declares LossType.Enthalpy. The "
+                f"compressor path does not implement it: Yp would silently "
+                f"remain 0 and the row would come out loss-free. "
+                + (
+                    "This model carries parasitic work (disc friction, "
+                    "recirculation, leakage). A parasitic loss raises T0 and "
+                    "destroys no total pressure, so it cannot be expressed as "
+                    "a pressure-loss coefficient at all: it belongs in the "
+                    "denominator of efficiency, and this solver has no "
+                    "parasitic-work term."
+                    if getattr(loss_fn, "is_parasitic", False)
+                    else
+                    "An internal loss can in principle be converted to a Yp, "
+                    "but that conversion is not implemented here."
+                )
+            )
 
     # Use the frozen target (if available) so diagnostic code can overwrite row.P0_ratio
     # without changing the initial guess used by this solver.

--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -18,6 +18,27 @@ from .outlet import OutletType
 __all__ = ["stator_calc", "rotor_calc", "polytropic_efficiency"]
 
 
+def _solve_bounded(func, bounds: list, what: str):
+    """minimize_scalar(..., method="bounded"), but a solution parked on a
+    bound is not a solution.
+
+    `method="bounded"` cannot leave its bracket: if the true root lies
+    outside [lo, hi], the optimizer converges onto the nearest edge and
+    reports `success=True` anyway. Returning that edge value silently would
+    mean applying a state that was never actually solved for.
+    """
+    res = minimize_scalar(func, bounds=bounds, method="bounded")
+    lo, hi = bounds
+    tol = 1e-4 * (hi - lo)
+    if res.x <= lo + tol or res.x >= hi - tol:
+        raise RuntimeError(
+            f"{what} converged onto the edge of its search bracket "
+            f"[{lo}, {hi}] at {res.x:.6g}: the solution lies outside the "
+            f"bracket and this result is not converged."
+        )
+    return res
+
+
 def polytropic_efficiency(pi: float, tau: float, gamma: float) -> float:
     """Compute polytropic efficiency from pressure/temperature ratios.
 
@@ -146,28 +167,28 @@ def stator_calc(row: BladeRow, upstream: BladeRow, calculate_vm: bool = True) ->
         return abs(target_massflow - total_massflow_local)
 
     def solve_massflow_for_current_loss() -> None:
-        res = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+        res = _solve_bounded(calculate_vm_func, [0.01, 1], "stator Mach")
         calculate_vm_func(res.x, apply=True)
 
     if calculate_vm:
         if loss_type == LossType.Polytropic and target_eta_poly is not None:
             def obj(y: float) -> float:
                 row.Yp[:] = y
-                res_local = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+                res_local = _solve_bounded(calculate_vm_func, [0.01, 1], "stator Mach")
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(row.eta_poly) - target_eta_poly)
 
-            res_y = minimize_scalar(obj, bounds=[0.0, 0.95], method="bounded")
+            res_y = _solve_bounded(obj, [0.0, 0.95], "stator Yp (polytropic-efficiency match)")
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         elif loss_type == LossType.Entropy and target_entropy is not None:
             def obj_entropy(y: float) -> float:
                 row.Yp[:] = y
-                res_local = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+                res_local = _solve_bounded(calculate_vm_func, [0.01, 1], "stator Mach")
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(np.mean(row.entropy_rise)) - target_entropy)
 
-            res_y = minimize_scalar(obj_entropy, bounds=[0.0, 0.95], method="bounded")
+            res_y = _solve_bounded(obj_entropy, [0.0, 0.95], "stator Yp (entropy-rise match)")
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         else:
@@ -326,28 +347,28 @@ def rotor_calc(
         return np.abs(upstream.total_massflow - total_massflow_local)
     
     def solve_massflow_for_current_loss() -> None:
-        res = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+        res = _solve_bounded(calculate_vm_func, [0.01, 1], "rotor relative Mach")
         calculate_vm_func(res.x, apply=True)
 
     if calculate_vm:
         if loss_type == LossType.Polytropic and target_eta_poly is not None:
             def obj(y: float) -> float:
                 row.Yp[:] = y
-                res_local = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+                res_local = _solve_bounded(calculate_vm_func, [0.01, 1], "rotor relative Mach")
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(row.eta_poly) - target_eta_poly)
 
-            res_y = minimize_scalar(obj, bounds=[0.0, 0.95], method="bounded")
+            res_y = _solve_bounded(obj, [0.0, 0.95], "rotor Yp (polytropic-efficiency match)")
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         elif loss_type == LossType.Entropy and target_entropy is not None:
             def obj_entropy(y: float) -> float:
                 row.Yp[:] = y
-                res_local = minimize_scalar(calculate_vm_func, bounds=[0.01, 1], method="bounded")
+                res_local = _solve_bounded(calculate_vm_func, [0.01, 1], "rotor relative Mach")
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(np.mean(row.entropy_rise)) - target_entropy)
 
-            res_y = minimize_scalar(obj_entropy, bounds=[0.0, 0.95], method="bounded")
+            res_y = _solve_bounded(obj_entropy, [0.0, 0.95], "rotor Yp (entropy-rise match)")
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         else:

--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -258,9 +258,9 @@ def rotor_calc(
         if np.isnan(W_local).any() or np.any(T_local >= T0R_local):
             return np.inf
 
-        Vr_local = W_local * np.sin(row.phi)
         beta2_eff = row.beta2 + deviation_rad
         Vm_local = W_local * np.cos(beta2_eff)
+        Vr_local = Vm_local * np.sin(row.phi)
         Wt_local = W_local * np.sin(beta2_eff)
         Vx_local = Vm_local * np.cos(row.phi)
         Vt_local = Wt_local + U_local

--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -282,10 +282,16 @@ def rotor_calc(
         deviation_val = deviation_func(row, upstream) if callable(deviation_func) else 0.0
         deviation_rad = np.radians(deviation_val)
 
-        P0R_local = upstream.P0R - row.Yp * (upstream.P0R - upstream.P)
         # Use rothalpy conservation: I = Cp*T0R - U^2/2 = const across rotor
         U_local = row.omega * row.r
         T0R_local = (upstream_rothalpy + 0.5 * U_local ** 2) / row.Cp
+        # The ideal (lossless) exit relative total pressure is isentropic between
+        # T0R_local and upstream.T0R, not a copy of upstream.P0R -- that identity
+        # holds only when U_local == upstream.U (see
+        # tests/test_relative_frame_oracle.py). Yp stays referenced to the
+        # upstream relative dynamic head, matching stator_calc's P0_is above.
+        P0R_ideal_local = upstream.P0R * (T0R_local / upstream.T0R) ** (row.gamma / (row.gamma - 1))
+        P0R_local = P0R_ideal_local - row.Yp * (upstream.P0R - upstream.P)
 
         P_local = P0R_local / IsenP(M_rel, row.gamma)
 
@@ -403,7 +409,11 @@ def rotor_calc(
 
         row.U = row.omega * row.r
         row.T0R = (upstream_rothalpy + 0.5 * row.U ** 2) / row.Cp
-        row.P0R = upstream.P0R - row.Yp * (upstream.P0R - upstream.P)
+        # Same isentropic identity as calculate_vm_func above -- this branch
+        # (calculate_vm=False) recomputes P0R independently for a multi-
+        # streamline row after radeq, so it must not regress to P0R2 = P0R1.
+        P0R_ideal = upstream.P0R * (row.T0R / upstream.T0R) ** (row.gamma / (row.gamma - 1))
+        row.P0R = P0R_ideal - row.Yp * (upstream.P0R - upstream.P)
 
         row.Vr = row.Vm * np.sin(row.phi)
         row.Vx = row.Vm * np.cos(row.phi)

--- a/turbodesign/compressor_math.py
+++ b/turbodesign/compressor_math.py
@@ -18,21 +18,35 @@ from .outlet import OutletType
 __all__ = ["stator_calc", "rotor_calc", "polytropic_efficiency"]
 
 
-def _solve_bounded(func, bounds: list, what: str):
+def _solve_bounded(
+    func, bounds: list, what: str, check_lower: bool = True, check_upper: bool = True
+):
     """minimize_scalar(..., method="bounded"), but a solution parked on a
-    bound is not a solution.
+    bound is not a solution -- unless that bound is itself a physical
+    constraint the answer is allowed to sit on.
 
     `method="bounded"` cannot leave its bracket: if the true root lies
     outside [lo, hi], the optimizer converges onto the nearest edge and
     reports `success=True` anyway. Returning that edge value silently would
-    mean applying a state that was never actually solved for.
+    mean applying a state that was never actually solved for -- but only if
+    the edge is an arbitrary numerical limit. A bound that encodes a real
+    physical constraint (e.g. a pressure-loss coefficient cannot be
+    negative) may legitimately hold the converged answer, and must not be
+    guarded. Use `check_lower=False` / `check_upper=False` to exempt a
+    bound that is physical rather than arbitrary.
     """
     res = minimize_scalar(func, bounds=bounds, method="bounded")
     lo, hi = bounds
     tol = 1e-4 * (hi - lo)
-    if res.x <= lo + tol or res.x >= hi - tol:
+    if check_lower and res.x <= lo + tol:
         raise RuntimeError(
-            f"{what} converged onto the edge of its search bracket "
+            f"{what} converged onto the lower edge of its search bracket "
+            f"[{lo}, {hi}] at {res.x:.6g}: the solution lies outside the "
+            f"bracket and this result is not converged."
+        )
+    if check_upper and res.x >= hi - tol:
+        raise RuntimeError(
+            f"{what} converged onto the upper edge of its search bracket "
             f"[{lo}, {hi}] at {res.x:.6g}: the solution lies outside the "
             f"bracket and this result is not converged."
         )
@@ -178,7 +192,9 @@ def stator_calc(row: BladeRow, upstream: BladeRow, calculate_vm: bool = True) ->
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(row.eta_poly) - target_eta_poly)
 
-            res_y = _solve_bounded(obj, [0.0, 0.95], "stator Yp (polytropic-efficiency match)")
+            res_y = _solve_bounded(
+                obj, [0.0, 0.95], "stator Yp (polytropic-efficiency match)", check_lower=False
+            )
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         elif loss_type == LossType.Entropy and target_entropy is not None:
@@ -188,7 +204,9 @@ def stator_calc(row: BladeRow, upstream: BladeRow, calculate_vm: bool = True) ->
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(np.mean(row.entropy_rise)) - target_entropy)
 
-            res_y = _solve_bounded(obj_entropy, [0.0, 0.95], "stator Yp (entropy-rise match)")
+            res_y = _solve_bounded(
+                obj_entropy, [0.0, 0.95], "stator Yp (entropy-rise match)", check_lower=False
+            )
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         else:
@@ -358,7 +376,9 @@ def rotor_calc(
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(row.eta_poly) - target_eta_poly)
 
-            res_y = _solve_bounded(obj, [0.0, 0.95], "rotor Yp (polytropic-efficiency match)")
+            res_y = _solve_bounded(
+                obj, [0.0, 0.95], "rotor Yp (polytropic-efficiency match)", check_lower=False
+            )
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         elif loss_type == LossType.Entropy and target_entropy is not None:
@@ -368,7 +388,9 @@ def rotor_calc(
                 calculate_vm_func(res_local.x, apply=True)
                 return abs(float(np.mean(row.entropy_rise)) - target_entropy)
 
-            res_y = _solve_bounded(obj_entropy, [0.0, 0.95], "rotor Yp (entropy-rise match)")
+            res_y = _solve_bounded(
+                obj_entropy, [0.0, 0.95], "rotor Yp (entropy-rise match)", check_lower=False
+            )
             row.Yp[:] = res_y.x
             solve_massflow_for_current_loss()
         else:

--- a/turbodesign/compressor_spool.py
+++ b/turbodesign/compressor_spool.py
@@ -1,6 +1,5 @@
 # type: ignore[arg-type, reportUnknownArgumentType]
 from __future__ import annotations
-from turtle import down, up
 from typing import Dict, List, Union, Optional, Tuple
 import json
 

--- a/turbodesign/loss/compressor/otac.py
+++ b/turbodesign/loss/compressor/otac.py
@@ -318,7 +318,7 @@ class ImpellerDiscFrictionDaily(LossBaseClass):
     """Daily & Nece disc friction loss."""
 
     def __init__(self, bf_gap: float | None = None, loss_modifier: float = 1.0):
-        super().__init__(LossType.Enthalpy)
+        super().__init__(LossType.Enthalpy, is_parasitic=True)
         self.bf_gap = bf_gap
         self.loss_modifier = loss_modifier
 
@@ -462,7 +462,7 @@ class ImpellerLeakageAungier(LossBaseClass):
         loading_coefficient: float = 1.0,
         loss_modifier: float = 1.0,
     ):
-        super().__init__(LossType.Enthalpy)
+        super().__init__(LossType.Enthalpy, is_parasitic=True)
         self.number_of_blades = number_of_blades
         self.splitter_le = splitter_le
         self.seal_clearance = seal_clearance
@@ -598,7 +598,7 @@ class ImpellerRecirculationAungier(LossBaseClass):
         lb: float | None = None,
         loss_modifier: float = 1.0,
     ):
-        super().__init__(LossType.Enthalpy)
+        super().__init__(LossType.Enthalpy, is_parasitic=True)
         self.number_of_blades = number_of_blades
         self.splitter_le = splitter_le
         self.loading_coefficient = loading_coefficient
@@ -638,7 +638,7 @@ class ImpellerRecirculationOh(LossBaseClass):
         surge_vrel: float = 1.0,
         loss_modifier: float = 1.0,
     ):
-        super().__init__(LossType.Enthalpy)
+        super().__init__(LossType.Enthalpy, is_parasitic=True)
         self.splitter_le = splitter_le
         self.loading_coefficient = loading_coefficient
         self.number_of_blades = number_of_blades
@@ -743,7 +743,12 @@ class ImpellerVarious(LossBaseClass):
     """Aggregate loss using multiple sub-correlations."""
 
     def __init__(self):
-        super().__init__(LossType.Enthalpy)
+        # This aggregate sums disc_friction + leakage + recirculation
+        # (all parasitic) together with internal terms into one number, so
+        # the whole aggregate must be treated as parasitic: it cannot be
+        # split back into a pure Yp any more than its parasitic components
+        # can.
+        super().__init__(LossType.Enthalpy, is_parasitic=True)
         # Compose key submodels with default parameters
         self.blade_loading = ImpellerBladeLoadingCoppage()
         self.clearance = ImpellerClearanceJansen()

--- a/turbodesign/loss/compressor/otac.py
+++ b/turbodesign/loss/compressor/otac.py
@@ -666,7 +666,7 @@ class ImpellerRecirculationOh(LossBaseClass):
             1e-6,
         )
 
-        dh = 8e-5 * np.sinh(3.5 * (np.radians(_mean(row.alpha2)) ** 3)) * Df**2 * (_mean(row.U) ** 2)
+        dh = 8e-5 * np.sinh(3.5 * (_mean(row.alpha2) ** 3)) * Df**2 * (_mean(row.U) ** 2)
         cp = _mean([row.Cp, upstream.Cp], row.Cp)
         cap = 0.5 * cp * (_mean(row.T0) - _mean(upstream.T0))
         dh = np.clip(dh * self.loss_modifier, 0.0, cap)

--- a/turbodesign/loss/losstype.py
+++ b/turbodesign/loss/losstype.py
@@ -9,19 +9,41 @@ class LossBaseClass(ABC):
     data: Dict[str,LossInterp]
     _loss_type:LossType
     
-    def __init__(self,lossType:LossType):
-        # Make the environment directory 
+    def __init__(self,lossType:LossType, is_parasitic:bool=False):
+        # Make the environment directory
         default_home = os.path.join(os.path.expanduser("~"), ".cache")
         os.environ['TD3_HOME'] = os.path.join(default_home,'TD3_LossModels')
         os.makedirs(os.environ['TD3_HOME'],exist_ok=True)
-        
+
         self._loss_type = lossType
+        self._is_parasitic = is_parasitic
 
     @abstractmethod
     def __call__(self, row:Any, upstream:Any) -> npt.NDArray:
         """Evaluate the loss for the supplied blade row."""
         raise NotImplementedError
-    
+
     @property
     def loss_type(self):
         return self._loss_type
+
+    @property
+    def is_parasitic(self) -> bool:
+        """Whether this model carries parasitic work, and therefore cannot be
+        expressed as a pressure-loss coefficient at all.
+
+        Internal loss (incidence, friction, clearance, mixing, shock, blade
+        loading, diffusion): destroys total pressure, does not change the
+        work. It can be expressed as a pressure-loss coefficient (Yp).
+
+        Parasitic loss (disc friction, recirculation, leakage, or an
+        aggregate that includes any of these): adds work (raises T0) and
+        destroys no total pressure. It belongs in the denominator of
+        efficiency, eta = (dh_Euler - dh_internal) / (dh_Euler +
+        dh_parasitic). It CANNOT be expressed as a Yp -- there is no pressure
+        term to attribute it to.
+
+        Defaults to False (internal); subclasses that carry parasitic work
+        must pass ``is_parasitic=True`` to this constructor.
+        """
+        return self._is_parasitic

--- a/turbodesign/turbine_spool.py
+++ b/turbodesign/turbine_spool.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from multiprocessing import Value
 import stat
-from turtle import down
 from typing import Dict, List, Union, Optional
 import json
 


### PR DESCRIPTION

Your Part I paper says the compressor path is not yet supported and is "a key area for future
development." This PR is offered in that spirit: eight defects in code your two validated turbine cases
do not execute, each with a test, each checkable from this repository alone.

**Your validated cases do not move.** The turbine goldens added here (EEE-HPT, radial turbine) are
byte-identical before and after, and CI asserts it on every push.

### The headline

`example9.1.py` builds both rows with `FixedPressureLoss(0)` — a **lossless, adiabatic rotor**, so
Δs across it must be zero. On `main`:

| streamline | Δs across the rotor, relative frame (J/kg·K) |
|---|---|
| hub | **+3.857** |
| mean | −0.605 |
| **shroud** | **−6.076** |

The shroud **destroys** entropy. Cause — two adjacent lines in `compressor_math.py`:

```python
P0R_local = upstream.P0R - row.Yp * (upstream.P0R - upstream.P)   # :246 -- Yp=0 => P0R2 == P0R1
T0R_local = (upstream_rothalpy + 0.5 * U_local ** 2) / row.Cp     # :249 -- from rothalpy => T0R2 != T0R1
```

Constant total pressure, rising total temperature, no heat added. `P0R₂,ideal = P0R₁` holds **iff
U₂ = U₁**, and the Mattingly cases fix the *mean* radius while shrinking the passage
(`example9.1.py:44-45`), so U changes per streamline. (Your paper's Eq 29c says T0R is conserved; its
Eq 21 assumes rothalpy conservation, which implies T0R changes with U. Line 246 implements the first,
line 249 the second.) After the fix Δs is `1e-4` — zero to solver tolerance.

### Found → fixed → result

| # | Found | Fix | Result |
|---|---|---|---|
| 1 | `compressor_math.py:246` — ideal exit relative total pressure set to `P0R₁`; true only if `U₂ = U₁`. Contradicted by `:249` three lines below, which computes `T0R₂` from rothalpy with the local `U`. | `P0R₂,ideal = P0R₁·(T0R₂/T0R₁)^(γ/(γ−1))` | **The only fix that moves a number.** Lossless rotor becomes isentropic (Δs → 1e-4). Rotor P0R hub/mean/shroud **+1.36 / −0.20 / −2.09 %** (9.1), **+1.23 / −0.19 / −1.90 %** (9.2). Overall PR −0.14 % / −0.13 %. T0R (+0.002 %) and absolute P0 (hub +0.76 %, shroud −1.81 %) also move — it feeds back through the massflow solve. |
| 2 | `bladerow.py` — `Yp` defaults to `np.array([0])`, an **int64** array; all eight compressor writes are in-place (`row.Yp[:] = y`), so every trial loss truncates to zero. The `Polytropic` and `Entropy` searches were optimising a constant. Turbine path is immune only because it rebinds. | `np.array([0.0])` | None on any example — but two of the compressor's three loss types were dead and now work. |
| 3 | `compressor_math.py:261` — `Vr = W*sin(phi)` uses the **relative** velocity. Your own `radial-equilibrium-derivation.md` (§11, §13 code-map) writes `Vr = Vm*np.sin(phi)`; `:85`, `:177`, `:365` in this same file already do. | `W` → `Vm` | None — every example sets `zero_phi=True`. Off-axis the old line overstated `Vr` by `1/cos(β₂)` (26 % at φ=90°) and broke `Vm² = Vx² + Vr²`. |
| 4 | 16 loss models declare `LossType.Enthalpy`. `compressor_math.py` has **no branch for it** → loss function never called, `Yp` silently 0, loss-free machine, no warning. `turbine_spool.py` implements the enthalpy→pressure loop (`:354`, `:628`, `:1178`); the compressor path never did. | Raise, naming the model. For the 4 **parasitic** ones (disc friction, both recirculations, leakage) the message adds that they contribute *work*, not pressure loss, so they cannot be a `Yp` at all. | None — nothing in `examples/` imports `otac`. Converts a silent loss-free machine into an honest error. |
| 5 | Every Mach solve is `minimize_scalar(bounds=[0.01, 1], method="bounded")`; for a rotor the free variable is the **relative** Mach. A bounded optimizer cannot leave its bracket — it parks on the edge and still returns `success == True`. | Raise when the solution lands on an **arbitrary** bound. Never on a physical one: `Yp = 0` is a legitimate answer, so its lower bound is exempt. | None on the Mattingly cases (M_rel ≈ 0.63, interior). **Diagnoses `eee-hpc.py` — see below.** |
| 6 | `otac.py:669` — `np.radians(row.alpha2)` where `alpha2` is **already radians** (`bladerow.py:584-586`). Cubed inside `sinh(3.5·x³)`. | drop the conversion | None — nothing imports `otac`. The loss was suppressed by (π/180)³ ≈ **5.3e-6**. |
| 7 | `compressor_spool.py:3` (`from turtle import down, up`) and `turbine_spool.py:6` (`from turtle import down`). Never used. `turtle` imports `tkinter` at module scope. | delete both (plus an unused `minimize`) | None. Fixes an `ImportError` on any Python without Tk — the normal case on a server or CI runner. |
| 8 | `requests` is imported at module scope by `craigcox`, `traupel`, `ainleymathieson`, `kackerokapuu` but is **not declared** in `[tool.poetry.dependencies]`. A clean `pip install turbo-design` raises `ImportError` on all four. | declare it | None. Survived because `requests` is present transitively in a dev environment; it is absent from a fresh CI runner, which is how the new test job found it. |

### Found, NOT fixed

| Found | Why not fixed here |
|---|---|
| **`examples/EEE-HPC/eee-hpc.py` does not run.** On `main`: `Exception: Invalid value of C 204.51 which causes Vm to be nan` (`radeq.py:99`). On this branch it fails earlier, at the cause: `stator Mach converged onto the upper edge of its search bracket [0.01, 1] at 0.999994`. `main` accepted a non-converged `M = 0.999994` and detonated two rows downstream. | **This PR diagnoses it, it does not fix it.** I tried widening the bracket past 1: it does *not* converge the example (still NaN, at `C 3.31`) and it *changes* the converged Mattingly answers — the massflow residual has multiple minima and `[0.01, 1]` was holding the solver on the right one. The real repair is to search on the **meridional** Mach, where choke actually lives. That is a solver change; I did not want to smuggle it in here. |
| **Band area in `flow_math.py:40`** adds a cubic metre to a square metre. **#27** (open since March) already proposes the same Pappus fix. | Deliberately **out of scope**. `compute_streamline_areas` is shared with `turbine_math.py`, so it *does* move your validated turbines — which is presumably why #27 has been hard to merge. The EEE-HPT goldens in this PR are exactly the regression evidence #27 has been missing; I would rather land this first and bring you that separately. |
| **Blade count vs splitters in `otac.py`** — four Aungier-family classes discount blade count for splitters, five use it raw. One family must be wrong. | Deciding which needs Coppage (1956), Oh (1997), Jansen (1967). I do not hold them. Filed as an issue. |
| **`RowType.CounterRotating = 2` collides with `RowType.Rotor = 2`.** Python aliases it, so it never appears in `list(RowType)` and a counter-rotating row is silently treated as a normal rotor. | The alias is certain; what you intend the member to mean is not. I have not guessed. Filed as an issue. |
| **`eee-hpc.py` needs `openpyxl`**, also undeclared. | Filed as an issue; the example does not run anyway (above). |

### Tests and CI

78 tests plus a GitHub Actions job — as far as I can tell the first in the repository, and the reason
any of the above is visible. Three kinds: **oracles** (band area, velocity triangle, relative-frame
state — checked against geometry and thermodynamics, not against the library); **characterization
goldens** (every example pinned per streamline, so any change that moves physics must declare its delta
in the diff); and one **defect test** per fix, red before and green after.

**What this does not claim:** it does not validate the solver. It shows eight defects are gone and that
the lossless case is now isentropic. Reproducing Mattingly's published answers would need the book,
which I do not have — the goldens record what the code *does*, not what is *correct*, and say so.

Happy to split any of this up, drop anything you disagree with, or rework the framing.

