### PR TITLE
Fix the red test suite on main: restore a lost fixture (51 errors), re-baseline the goldens #27 correctly moved, revive two dead loss models

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,3 +110,16 @@ def example_spool():
         return cache[name]
 
     return _load
+
+
+@pytest.fixture(scope="session")
+def data_dir() -> Path:
+    """Repository `data/` directory.
+
+    Required by every test under tests/unit/ that reads a committed machine definition.
+    It was defined in the conftest.py that arrived with the centrifugal module and was
+    lost when that conftest and this one were reconciled: the surviving file kept
+    `example_spool` and dropped this, leaving 51 tests erroring at setup with
+    "fixture 'data_dir' not found".
+    """
+    return REPO_ROOT / "data"

--- a/tests/test_band_area_oracle.py
+++ b/tests/test_band_area_oracle.py
@@ -19,11 +19,16 @@ from scipy.integrate import quad
 
 
 def buggy_band_area(x1, r1, x2, r2):
-    """Verbatim reproduction of flow_math.py:40 (upstream 4018a6c).
+    """Verbatim reproduction of flow_math.py:40 as it stood at upstream 4018a6c.
 
     S is a length in metres, so S/2 * dx**2 is a cubic metre, and it is added to r1*dx,
-    a square metre. tests/test_current_area_formula.py checks that this reproduction still
-    matches the library.
+    a square metre.
+
+    SUPERSEDED: the library no longer computes this. PR #27
+    (`fix/radial-area-and-massflow-sign`) replaced it with the exact frustum area, which is
+    what `pappus_band_area` below has always returned. This function is kept as the record
+    of the old expression, and `tests/test_current_area_formula.py` now uses it as a
+    regression tripwire -- it asserts the library does NOT match this any more.
     """
     dx = x2 - x1
     S = r2 - r1  # metres -- not a slope

--- a/tests/test_current_area_formula.py
+++ b/tests/test_current_area_formula.py
@@ -39,7 +39,11 @@ and on the cone below it was 15% low.
 import numpy as np
 import pytest
 
-from tests.test_band_area_oracle import buggy_band_area, pappus_band_area
+from tests.test_band_area_oracle import (
+    buggy_band_area,
+    pappus_band_area,
+    slope_variant_band_area,
+)
 from turbodesign.bladerow import BladeRow
 from turbodesign.flow_math import compute_streamline_areas
 
@@ -102,3 +106,45 @@ def test_the_area_is_dimensionally_homogeneous():
     scaled, _ = compute_streamline_areas(scaled_row)
 
     assert scaled / plain == pytest.approx(k**2, rel=1e-12)
+
+
+def test_the_library_returns_a_SIGNED_area_not_a_geometric_one():
+    """The library's area is signed: reverse the cut and it changes sign.
+
+    This is deliberate in PR #27 -- `# Signed area: sign follows dx to maintain massflow
+    sign convention` -- and this test does not argue with it. It pins it, because nothing
+    else does, and because the sign is invisible in every forward-ordered case the rest of
+    this file exercises.
+
+    Note what the suite already says about this shape. `slope_variant_band_area` in the
+    oracle is "the obvious repair to buggy_band_area ... It fixes the dimensional error but
+    not the sign", and `test_area_is_never_negative_for_a_reversed_cut` records the verdict:
+    a reversed cut "returns a negative area, which Pappus -- and an area -- cannot."
+
+    The library now computes that variant EXACTLY, reversed cuts included. So the geometric
+    magnitude is right and agrees with Pappus, while the sign is a flow-direction convention
+    carried on the same number as the area. That is a real design decision and it may well be
+    the intended one; it is pinned here so that changing it cannot pass unnoticed, and so the
+    disagreement with the geometric oracle is stated rather than latent.
+    """
+    forward, _ = compute_streamline_areas(_cone_row())
+
+    reversed_row = BladeRow()
+    reversed_row.percent_hub_shroud = np.array([0.0, 1.0])
+    reversed_row.x = np.array([X2, X1])
+    reversed_row.r = np.array([R2, R1])
+    backward, _ = compute_streamline_areas(reversed_row)
+
+    # Magnitude: agrees with the geometric oracle in both directions.
+    exact = pappus_band_area(X1, R1, X2, R2)
+    assert abs(forward) == pytest.approx(exact, rel=1e-12)
+    assert abs(backward) == pytest.approx(exact, rel=1e-12)
+
+    # Sign: the convention. Pappus is unsigned and cannot express this.
+    assert forward > 0.0
+    assert backward < 0.0
+    assert backward == pytest.approx(-forward, rel=1e-12)
+
+    # And it is precisely the variant the oracle names and rejects as a geometric area.
+    assert forward == pytest.approx(slope_variant_band_area(X1, R1, X2, R2), rel=1e-12)
+    assert backward == pytest.approx(slope_variant_band_area(X2, R2, X1, R1), rel=1e-12)

--- a/tests/test_current_area_formula.py
+++ b/tests/test_current_area_formula.py
@@ -1,5 +1,5 @@
 # tests/test_current_area_formula.py
-"""Tie the reproduction in test_band_area_oracle.py to the library it reproduces.
+"""Tie the reproductions in test_band_area_oracle.py to the library they reproduce.
 
 test_band_area_oracle.py deliberately does not import turbodesign: it is an oracle, and it
 has to be able to disagree with the library. The cost of that is a copy of flow_math.py's
@@ -7,12 +7,33 @@ band-area expression sitting in the test suite with nothing holding the two toge
 the formula in the library changes, the copy becomes a stale reproduction of a formula that
 no longer exists, and the oracle's tests keep passing while asserting nothing about the code.
 
-This file is the tie. It imports turbodesign and checks that
-`flow_math.compute_streamline_areas` still computes what `buggy_band_area` reproduces.
+This file is the tie.
 
-It is expected to fail when the area formula is fixed, and it should then be updated: at
-that point `buggy_band_area` is a record of the old formula, `compute_streamline_areas`
-should agree with `pappus_band_area` instead, and this file should say so.
+THE FORMULA HAS NOW BEEN FIXED (PR #27, `fix/radial-area-and-massflow-sign`). This file
+previously pinned `compute_streamline_areas` to `buggy_band_area` and stated, in its own
+docstring, what to do on the day the fix landed:
+
+    "It is expected to fail when the area formula is fixed, and it should then be updated:
+    at that point `buggy_band_area` is a record of the old formula,
+    `compute_streamline_areas` should agree with `pappus_band_area` instead, and this file
+    should say so."
+
+This is that update, and this file now says so. `compute_streamline_areas` is checked
+against `pappus_band_area` -- the exact lateral area of the frustum the two points define,
+pi*(r1 + r2)*slant. `buggy_band_area` is retained in the oracle purely as a record of the
+old expression, and is used here in the opposite direction: to assert the library has NOT
+regressed back to it.
+
+Why the old one was wrong, for the record. It read
+
+    S = r2 - r1                       # a LENGTH, in metres -- not a slope
+    C = sqrt(1 + (S/dx)**2)
+    area = 2*pi*C*(S/2 * dx**2 + r1*dx)
+
+`S/2 * dx**2` is a cubic metre and it was added to `r1*dx`, a square metre. A sum whose
+terms carry different dimensions cannot be right in any unit system, and the consequence is
+not small: the expression is exact only for a cylinder (S = 0, where the bad term vanishes),
+and on the cone below it was 15% low.
 """
 
 import numpy as np
@@ -35,24 +56,49 @@ def _cone_row() -> BladeRow:
     return row
 
 
-def test_the_library_still_computes_what_the_oracle_reproduces():
-    """If this fails, either the library's area formula changed or the reproduction drifted.
-    Either way test_band_area_oracle.py needs updating -- that is what this test is for.
+def test_the_library_computes_the_exact_geometric_area():
+    """`compute_streamline_areas` must equal the surface of revolution the geometry defines.
+
+    If this fails, either the library's area formula changed again or the Pappus
+    reproduction drifted. Either way test_band_area_oracle.py needs updating -- that is what
+    this test is for.
     """
     total_area, streamline_area = compute_streamline_areas(_cone_row())
-    expected = buggy_band_area(X1, R1, X2, R2)
-    assert streamline_area[1] == pytest.approx(expected, rel=1e-12)
-    assert total_area == pytest.approx(expected, rel=1e-12)
+    exact = pappus_band_area(X1, R1, X2, R2)
+    assert streamline_area[1] == pytest.approx(exact, rel=1e-12)
+    assert total_area == pytest.approx(exact, rel=1e-12)
 
 
-def test_the_library_area_is_currently_below_the_geometric_area_on_a_cone():
-    """The consequence, stated against the library rather than against the reproduction: on
-    this cone the area the library computes is 15.0% below the surface of revolution the
-    geometry defines. Fixing flow_math.py:40 will make these two agree and this test fail.
+def test_the_library_has_not_regressed_to_the_dimensionally_broken_formula():
+    """The tripwire in the other direction.
+
+    `buggy_band_area` is 15% low on this cone. Pinning the gap keeps the old expression
+    from creeping back in unnoticed -- and keeps `buggy_band_area` itself honest, since a
+    reproduction nothing exercises is a reproduction nobody notices going stale.
     """
     total_area, _ = compute_streamline_areas(_cone_row())
-    exact = pappus_band_area(X1, R1, X2, R2)
-    err = (total_area - exact) / exact
+    old = buggy_band_area(X1, R1, X2, R2)
+    err = (old - total_area) / total_area
     assert err == pytest.approx(-0.150, abs=0.001), (
-        f"library area {total_area:.6f} m2 vs geometric area {exact:.6f} m2 ({err:.2%})"
+        f"the superseded formula gives {old:.6f} m2 against the library's {total_area:.6f} m2 "
+        f"({err:.2%}). If this gap has closed, the library may have regressed to it."
     )
+
+
+def test_the_area_is_dimensionally_homogeneous():
+    """Scale the whole geometry by k; a true area must scale by k**2, exactly.
+
+    This is the check that would have caught the old formula on day one, without knowing
+    anything about frustums: it summed a cubic metre and a square metre, so it scaled as
+    neither. It came out ~5.97e6 across a 1e3 length scaling where an area must give 1e6.
+    """
+    k = 1000.0
+    plain, _ = compute_streamline_areas(_cone_row())
+
+    scaled_row = BladeRow()
+    scaled_row.percent_hub_shroud = np.array([0.0, 1.0])
+    scaled_row.x = np.array([X1 * k, X2 * k])
+    scaled_row.r = np.array([R1 * k, R2 * k])
+    scaled, _ = compute_streamline_areas(scaled_row)
+
+    assert scaled / plain == pytest.approx(k**2, rel=1e-12)

--- a/tests/test_turbine_characterization.py
+++ b/tests/test_turbine_characterization.py
@@ -219,54 +219,78 @@ def test_radial_turbine_massflow_attribute_is_the_input_echo(example_spool):
     assert spool.massflow == pytest.approx(0.1, rel=RTOL)
 
 
+# --------------------------------------------------------------------------------------
+# RE-BASELINED at PR #27 (`fix/radial-area-and-massflow-sign`).
+#
+# The three radial-turbine goldens below moved because `compute_streamline_areas` changed:
+# the band area is now the exact frustum area pi*(r1 + r2)*slant instead of an expression
+# that added a cubic metre to a square metre. See tests/test_current_area_formula.py.
+#
+# These are CHARACTERIZATION tests. They pin behaviour so that a change cannot pass
+# unnoticed; they are not statements that the pinned numbers are correct. They fired exactly
+# as designed, and the values are re-taken from the example rather than adjusted to fit.
+# Only the radial cases move -- every axial golden in this file is untouched, which is the
+# expected signature of a change to the RADIAL branch of the area calculation.
+# --------------------------------------------------------------------------------------
+
+
 def test_radial_turbine_stator_per_streamline(example_spool):
     row = example_spool("radial-turbine/radial_turbine-1D.py")["stator"]
     assert row.P0 == pytest.approx([536657.313099755] * 5, rel=RTOL)
     assert row.T0 == pytest.approx([1222.8779357137] * 5, rel=RTOL)
-    assert row.M == pytest.approx([0.42080703647747797] * 5, rel=RTOL)
+    # was 0.42080703647747797 before the area fix; P0/T0/Yp are unchanged by it.
+    assert row.M == pytest.approx([0.49044906439126945] * 5, rel=RTOL)
     assert row.Yp == pytest.approx([0.0] * 5, abs=1e-12)
 
 
 def test_radial_turbine_rotor_per_streamline(example_spool):
-    """The golden most likely to move once the shared area fix lands.
+    """The golden that was flagged as most likely to move once the area fix landed. It did.
 
     `M` here is the absolute Mach number, and it exceeds 1 at the hub streamline
-    (M[0] = 1.2696). That is not a choked passage: choking is set by the meridional Mach
+    (M[0] = 1.2320). That is not a choked passage: choking is set by the meridional Mach
     number, which is far lower at a near-radial station, and a swirling flow can carry an
     absolute Mach number above 1 without it. It is also exactly the kind of station where
-    the extra term in `compute_streamline_areas` is large rather than negligible.
+    the corrected term in `compute_streamline_areas` is large rather than negligible --
+    which is why this row moved and the axial rows did not.
     """
     row = example_spool("radial-turbine/radial_turbine-1D.py")["rotor"]
+    # pre-fix P0: [443074.15148622065, 437651.6584138988, 428537.84499390324,
+    #              418045.0960861983, 409980.2644715815]
     assert row.P0 == pytest.approx(
         [
-            443074.15148622065,
-            437651.6584138988,
-            428537.84499390324,
-            418045.0960861983,
-            409980.2644715815,
+            434029.9135235289,
+            428744.0618755014,
+            419931.65779237944,
+            409786.61084366404,
+            401992.02228410816,
         ],
         rel=RTOL,
     )
+    # pre-fix T0: [1161.8429099481775, 1158.73767317465, 1153.2557718494477,
+    #              1146.9118258635594, 1142.398479508869]
     assert row.T0 == pytest.approx(
         [
-            1161.8429099481775,
-            1158.73767317465,
-            1153.2557718494477,
-            1146.9118258635594,
-            1142.398479508869,
+            1154.970831024012,
+            1151.9058186779316,
+            1146.5434634683434,
+            1140.3418075933444,
+            1135.9434687109626,
         ],
         rel=RTOL,
     )
+    # pre-fix M: [1.269577634397641, 0.9756593824217092, 0.882204528319701,
+    #             0.837409532372009, 0.7773593618539902]
     assert row.M == pytest.approx(
         [
-            1.269577634397641,
-            0.9756593824217092,
-            0.882204528319701,
-            0.837409532372009,
-            0.7773593618539902,
+            1.2319911973203372,
+            0.9525978451296234,
+            0.8626853849786268,
+            0.8193645118214383,
+            0.7607708835335303,
         ],
         rel=RTOL,
     )
+    # Yp is set by the loss model, not the area, and is unchanged by the fix.
     assert row.Yp == pytest.approx([0.1358751871641363] * 5, rel=RTOL)
 
 
@@ -274,12 +298,16 @@ def test_radial_turbine_convergence_tripwire(example_spool):
     """Coarse tripwire on the pressure-balance solve (see the EEE-HPT equivalent
     above for why this is coarse rather than exact: `minimize_scalar`'s own result
     object is internal to `_balance_pressure` and is not exposed on `spool`).
+
+    The iteration count is unchanged at 15 -- the corrected area moved where the solve
+    lands, not how hard it was to get there.
     """
     spool = example_spool("radial-turbine/radial_turbine-1D.py")["spool"]
     assert len(spool.convergence_history) == 15
     last = spool.convergence_history[-1]
-    assert last["massflow_std"] == pytest.approx(2.7887726216979658e-05, rel=1e-6)
-    assert last["massflow"] == pytest.approx(0.29864834362636516, rel=1e-6)
+    # pre-fix: massflow_std 2.7887726216979658e-05, massflow 0.29864834362636516
+    assert last["massflow_std"] == pytest.approx(2.457223793289609e-05, rel=1e-6)
+    assert last["massflow"] == pytest.approx(0.3357569515451556, rel=1e-6)
 
 
 @pytest.mark.slow

--- a/tests/unit/test_loss_set_is_not_vacuous.py
+++ b/tests/unit/test_loss_set_is_not_vacuous.py
@@ -77,6 +77,25 @@ def op(data_dir):
             tip_clearance=0.000305,
             inducer_blade_angle_deg=BETA1B_RMS,
             le_blade_thickness=LE_BLADE_THICKNESS,
+            # Item 10 / debt D5. These three were absent, and their absence -- not any
+            # defect in the models -- is what made ImpellerEntranceDiffusionAungier and
+            # ImpellerMixingAungier contribute exactly zero. All are NASA-derived and are
+            # what my_scripts/hecc_stage.py's IMPELLER has been passing in production.
+            #
+            # Inducer throat: minimum distance between adjacent MAIN blades, 15 passages,
+            # from Appendix C surface coordinates (data/hecc/throat_areas.csv,
+            # my_scripts/extract_hecc_throat_areas.py). Without it A_th := A1, which
+            # overstates the real throat by 53%.
+            throat_area=0.020525,
+            # TE GEOMETRIC (metal) blockage from Appendix C. With blockage2 = 0 the mixing
+            # loss's W_out reduces to W2 exactly, so W_sep - W_out == 0 and the loss is
+            # identically zero -- an algebraic identity, not physics.
+            blockage=0.015837,
+            # Camberline lengths (my_scripts/extract_hecc_blade_angles.py). Without these
+            # the mixing loss falls back to the UNVERIFIED length closure.
+            l_main_m=0.209875,
+            l_splitter_m=0.145580,
+            l_blade_m=0.237875,
         ),
         diffuser=None,
         slip=WiesnerSlip(),
@@ -89,12 +108,27 @@ def op(data_dir):
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "KNOWN DEFECT, not a flake. 3 of 10 losses are identically zero: "
-        "ImpellerIncidenceConrad (no inducer blade-metal-angle field -> beta_opt := "
-        "beta_1xi -> W* == 0; angle now derived in data/hecc/blade_angles.csv, wiring "
-        "is item 5e), ImpellerChokeAungier + ImpellerEntranceDiffusionAungier (no throat "
-        "station -> A_th := A1; debt D5, item 10). strict=True: when these are wired, "
-        "this test MUST start passing and the marker must be removed."
+        "KNOWN DEFECT, not a flake -- but now ONE loss, not three. 2026-08-01: "
+        "ImpellerIncidenceConrad is RESURRECTED (item 5e: beta1b_deg is wired and the "
+        "model now RAISES rather than falling back to the flow angle), and "
+        "ImpellerEntranceDiffusionAungier + ImpellerMixingAungier were revived by giving "
+        "this fixture the geometry production has always passed (throat_area, blockage, "
+        "camberline lengths -- item 10 / debt D5). Note ImpellerMixingAungier was dead and "
+        "the previous version of THIS REASON did not even name it: with blockage2 = 0 its "
+        "W_out reduces to W2 exactly, so W_sep - W_out == 0 identically. "
+        "WHAT REMAINS: ImpellerChokeAungier alone, and for a sharper reason than 'no "
+        "throat station' -- the throat IS wired now. Its onset gate (x <= 0 -> return 0) "
+        "never opens inside the envelope the solver can reach: measured dh == 0.000000 "
+        "EXACTLY at the largest mdot that converges, at 80/90/100/105% speed; the "
+        "solver's own meridional-Mach choke criterion trips first (Choked raised at "
+        "mdot 5.90 vs 5.85 solving, at design speed). An onset loss whose onset lies "
+        "outside the solvable envelope cannot be evidence. "
+        "DO NOT close this by lowering onset_threshold or onset_scale -- those are "
+        "published Aungier/Kovar constants and moving them to make a test pass is "
+        "precisely what docs/DO-NOT-FIT.md forbids. Resolve the disagreement between "
+        "Aungier's onset criterion and the solver's choke criterion instead. "
+        "strict=True: when it is resolved, this test MUST start passing and the marker "
+        "must be removed."
     ),
 )
 def test_every_configured_loss_actually_contributes(op):


### PR DESCRIPTION
## `main` is currently red, and 51 more tests are not running at all

On `main` at `a300cd7`, `pytest tests/` reports:

```
5 failed, 242 passed, 51 errors
```

This PR takes it to:

```
300 passed, 4 xfailed
```

Four findings, one commit each. **No library file is modified — the diff is tests-only.**

---

### 1. `data_dir` was dropped when the two conftests were reconciled — 51 tests error at setup

Every test under `tests/unit/` that reads a committed machine definition takes a `data_dir`
fixture. It was defined in the `conftest.py` that arrived with the centrifugal module (#36)
and is absent from the one now on `main`: when that file and the one from #35 were
reconciled, the survivor kept `example_spool` and lost `data_dir`.

So the entire centrifugal unit suite — 51 tests — currently errors at setup with
`fixture 'data_dir' not found`. They don't fail; they never run. The suite reports no red
for them while asserting nothing whatsoever.

The fix is an addition, not a reconciliation: the fixture is restored and nothing else in
the file changes. All 51 then collect and pass.

### 2. Five characterization tests were pinning the pre-#27 area formula

**#27 is correct and this PR does not touch it.** The expression it replaced read:

```python
S = r2 - r1                       # a LENGTH, in metres -- not a slope
C = sqrt(1 + (S/dx)**2)
area = 2*pi*C*(S/2 * dx**2 + r1*dx)
```

`S/2 * dx**2` is a cubic metre, and it was added to `r1*dx`, a square metre. A sum whose
terms carry different dimensions cannot be right in any unit system. Measured against the
closed-form frustum area:

| geometry | old / exact | new / exact |
|---|---|---|
| cylinder (`dr = 0`) | 1.0000 | 1.0000 |
| cone 0.10 → 0.12 over `dx = 0.05` | 0.9136 | 1.0000 |
| steep cone 0.05 → 0.20 over `dx = 0.05` | **0.4300** | 1.0000 |

It was exact only for a cylinder — precisely the case where the bad term vanishes.

The five tests that broke are *characterization* tests. Their job is to make a behaviour
change impossible to miss, not to assert that the pinned numbers are right. They fired
exactly as designed. `tests/test_current_area_formula.py` had already written down what to
do on this day:

> *"It is expected to fail when the area formula is fixed, and it should then be updated: at
> that point `buggy_band_area` is a record of the old formula, `compute_streamline_areas`
> should agree with `pappus_band_area` instead, and this file should say so."*

This is that update.

- **`test_current_area_formula.py`** now asserts agreement with `pappus_band_area`, and
  keeps the tripwire pointing the *other* way — asserting the library has **not** regressed
  to the superseded expression. Adds a scaling test: scale the geometry by `k`, and a true
  area must scale by `k²` exactly. That check would have caught the old formula on day one
  without knowing anything about frustums — it scaled as neither a length nor an area
  (~5.97e6 across a 1e3 length scaling, where an area must give 1e6).
- **`test_band_area_oracle.py`** — `buggy_band_area` is relabelled SUPERSEDED and kept as
  the record of what the library used to compute. Docstring only.
- **`test_turbine_characterization.py`** — three radial-turbine goldens re-taken from the
  example, not adjusted to fit. Superseded values are kept inline as comments. **Only the
  radial cases move; every axial golden is untouched**, which is the expected signature of a
  change to the radial branch. The iteration count is unchanged at 15 — the corrected area
  moved where the solve lands, not how hard it was to get there.

---

### 3. The signed-area convention had no test at all

`compute_streamline_areas` now returns a **signed** area — reverse the cut and it changes
sign. That is deliberate (`# Signed area: sign follows dx to maintain massflow sign
convention`), and **this PR does not argue with it or change it.** But nothing exercised it:
every other case in `test_current_area_formula.py` is forward-ordered, so the sign is
invisible and a change to it would pass silently.

What makes this worth a test rather than a comment is that the suite already had an opinion
about this exact shape, written before #27 landed. The oracle defines:

```python
def slope_variant_band_area(x1, r1, x2, r2):
    """The obvious repair to buggy_band_area: redefine S as the slope dr/dx rather than a
    length ... It fixes the dimensional error but not the sign, which is what
    test_area_is_never_negative_for_a_reversed_cut measures.
    """
```

and `test_area_is_never_negative_for_a_reversed_cut` records the verdict — a reversed cut
"returns a negative area, which Pappus — and an area — cannot."

**The library now computes that variant exactly**, reversed cuts included (verified identical
on forward and reversed cuts of two different cones). So the geometric magnitude is right and
agrees with Pappus in both directions, while the sign is a flow-direction convention riding on
the same number as the area.

The new test pins that, so the convention is stated rather than latent. If it is the intended
design — and it may well be — nothing changes except that it is now written down where the
next reader meets it. Related, and untouched: `compressor_math.rotor_calc`'s residual is
`np.abs(np.abs(a) - np.abs(b))`, which cannot distinguish a genuine sign error from a
convention one. Flagging, not changing — happy to open a separate issue if useful.

### 4. Two loss models were contributing exactly zero — because the fixture withheld geometry

`tests/unit/test_loss_set_is_not_vacuous.py::test_every_configured_loss_actually_contributes`
is `xfail(strict=True)` over a stated defect: *"3 of 10 losses are identically zero"*. Two of
the three were not model defects at all — the fixture simply wasn't passing geometry that is
already derived and committed in `data/hecc/`.

Added to the fixture (all NASA-derived, nothing invented, nothing tuned):

| field | value | why it mattered |
|---|---|---|
| `throat_area` | 0.020525 | inducer throat from Appendix C surface coordinates. Without it `A_th := A1`, overstating the real throat by **53%** and making the entrance-diffusion loss structurally inert |
| `blockage` | 0.015837 | TE metal blockage from Appendix C. With `blockage2 = 0` the mixing loss's `W_out` reduces to `W2` **exactly**, so `W_sep - W_out == 0` — the loss was zero *by algebra*, not by physics |
| `l_main_m`, `l_splitter_m`, `l_blade_m` | measured | without them the mixing loss falls back to an UNVERIFIED length closure |

**Dead losses: 3 → 1.** `ImpellerEntranceDiffusionAungier` and `ImpellerMixingAungier` now
contribute.

The marker's own reason string was stale in two ways, and both are corrected: it blamed
`ImpellerIncidenceConrad` (no longer dead), and it never named `ImpellerMixingAungier`
(which was).

**What remains — and it is worth a second look.** `ImpellerChokeAungier` is still zero, but
for a sharper reason than "no throat station", since the throat is now wired. Its onset gate
(`if x <= 0: return 0`) never opens inside the envelope the solver can reach:

| speed | last mdot that solves | choke-loss Δh there |
|---|---|---|
| 80% | 5.50 | 0.000000 |
| 90% | 5.65 | 0.000000 |
| 100% | 5.85 | 0.000000 |
| 105% | 5.95 | 0.000000 |

The solver's own meridional-Mach choke criterion trips first (`Choked` raised at mdot 5.90
against 5.85 solving, at design speed). So Aungier's onset criterion and the solver's choke
criterion disagree about where choke begins, and the loss sits permanently on the wrong side
of that gap. **The marker stays** — I have not closed it by moving `onset_threshold` or
`onset_scale`, which are published Aungier/Kovář constants. If you know which of the two
criteria you'd rather trust, that's the fix.

**The xfail count is unchanged at 4.** This shrinks the defect inside one of them from three
models to one; it does not close it.

---

### Verification

```
main   (a300cd7):  5 failed, 242 passed, 51 errors,  3 loss models silently zero
this PR:                     300 passed,  4 xfailed,  1 loss model silently zero
```

No library file is modified — the diff is four files, all under `tests/`.

Assertion strength was checked by fault injection rather than assumed. With the library
deliberately mutated, `tests/test_current_area_formula.py` reports:

| injected fault | result |
|---|---|
| remove the sign convention | 1 failed, 3 passed |
| revert to the old broken formula | 4 failed |
| drop the slant, use `dx` | 3 failed, 1 passed |
| `2*pi` instead of `pi` | 3 failed, 1 passed |

Every mutation is caught, and each by the test that claims to catch it.

### One thing deliberately not done

The three radial-turbine goldens are full-precision float lists taken from running the
example. They detect *change*, not *wrongness* — which is what a characterization test is for,
and they now say so. A better instrument for the same risk would be a few invariants on the
radial solve (rothalpy conservation, massflow continuity across stations) that survive
re-baselines and say something a float list cannot. That is a change to the project's testing
strategy rather than a repair, so it is not in this PR. Happy to propose it separately if
that is welcome.
